### PR TITLE
Token auth fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,8 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Personal notes and temporary files
+__*.md
+nul
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,3 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-# Personal notes and temporary files
-__*.md
-nul
-.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-mcp-server",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-mcp-server",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0",

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -871,6 +871,7 @@ describe('SignalKClient', () => {
       expect(client.connected).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/signalk/v1/api/vessels/self'),
+        {}, // buildFetchOptions() returns empty object when no token
       );
     });
 


### PR DESCRIPTION
This changes work for me to access a remote Signal K Server via http:// accessing from a local windows machine with Claude Desktop.

my  **claude_desktop_config.json** for local testing purposes:
```
{
  "mcpServers": {
    "signalk": {
      "command": "docker",
      "args": [
        "run",
        "--rm",
        "-i",
        "-v",
        "/c/Users/Mastercabin/OneDrive/Dokumente/GitHub/signalk-mcp-server:/workspace",
        "-w",
        "/workspace",
        "-e",
        "SIGNALK_HOST=192.168.0.10",
        "-e",
        "SIGNALK_PORT=3000",
        "-e",
        "SIGNALK_TLS=false",
        "-e",
        "EXECUTION_MODE=code",
        "node:20",
        "node",
        "dist/src/index.js"
      ]
    }
  }
}
```