### PR TITLE
chore: modernize CI, publishing, dependencies, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
           --health-retries 5
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v5
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -73,7 +73,7 @@ jobs:
     
     - name: Upload coverage reports
       if: matrix.node-version == '20.x'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-report
         path: coverage/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,20 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    
+    # Newer Node versions may not yet have an isolated-vm prebuilt; those legs
+    # are allowed to fail (the server must still boot — execute_code degrades
+    # gracefully once isolated-vm is an optional, lazily-loaded dependency).
+    continue-on-error: ${{ matrix.experimental || false }}
+
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: ['20.x', '22.x']
+        include:
+          - node-version: '24.x'
+            experimental: true
+          - node-version: '25.x'
+            experimental: true
     
     # Note: Service containers don't support custom commands/arguments
     # We'll use docker compose in the e2e-tests.yml workflow instead

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
@@ -53,7 +53,7 @@ jobs:
           echo "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify package version matches tag
@@ -53,15 +53,15 @@ jobs:
           echo "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body_path: release_notes.txt
           draft: false
           prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the SignalK MCP Server project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Server no longer crashes at startup on Node versions without an `isolated-vm` build (e.g. Node 25).** `isolated-vm` was imported unconditionally at module load, so a missing/unbuildable native addon killed the process before it could answer the MCP `initialize` request. It is now loaded lazily (dynamic import on first `execute_code`) and declared as an `optionalDependency`, so the server always boots and `npm install` / `npx` never hard-fail. `execute_code` returns a clear "code execution unavailable" message when the addon cannot be loaded.
+
+### Changed
+- Upgraded `@modelcontextprotocol/sdk` from `^0.5.0` to `^1.29.0`. The low-level `Server` API is unchanged; `tsconfig` `moduleResolution` is set to `bundler` so the SDK's `exports`-map subpaths resolve. Added `zod` as an explicit dependency.
+- Moved `isolated-vm` to `optionalDependencies` and bumped it to `^6.1.2` (supports Node >=22). **Node 22 LTS is recommended** for full `execute_code` support with V8 isolation.
+- Bumped `dotenv` to `^17` (startup banner silenced with `quiet: true` to keep stdout clean for the stdio transport); removed the deprecated `@types/dotenv` stub; aligned `@types/node` to the supported LTS range.
+- Raised `engines.node` to `>=20.18.0`. CI now runs on Node 20/22 (required) and 24/25 (non-blocking); the npm publish workflow uses `softprops/action-gh-release@v2` and Node 22.
+
 ## [1.0.8] - 2025-11-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ MCP (Model Context Protocol) server that provides AI agents with access to Signa
 - Discover available data paths on the SignalK installation
 
 ## TECHNICAL REQUIREMENTS
-Runtime: Node.js 18+ (native fetch support)
+Runtime: Node.js 20.18+ (Node 22 LTS recommended; native fetch support)
 Transport: HTTP REST API to SignalK server
 Protocol: MCP (Model Context Protocol)
 Data Format: JSON (SignalK data)
 Architecture: V8 isolate-based code execution with RPC bindings
-Dependencies: isolated-vm for secure code execution
+Dependencies: isolated-vm (optional, lazily loaded) for secure code execution — requires a Node version with a working isolated-vm build (Node 22 LTS recommended)
 
 ## EXPLICITLY OUT OF SCOPE (MVP)
 - NO collision avoidance calculations

--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ SERVER_VERSION=1.0.6
 
 ### Prerequisites
 
-- Node.js 18.0.0 or higher
+- **Node.js 20.18+ (Node 22 LTS recommended)**
 - Access to a SignalK server
+
+> **Code execution & Node version:** `execute_code` runs in a V8 isolate via the native [`isolated-vm`](https://github.com/laverdet/isolated-vm) addon, which is an **optional dependency**. The server always starts regardless, but `execute_code` only works on a Node version that has a working `isolated-vm` build — **Node 22 LTS is recommended**. On a Node version without one (e.g. Node 25), the server still boots and the other tools work, but `execute_code` reports that code execution is unavailable.
 
 ### Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0",
         "@signalk/client": "^2.3.0",
-        "dotenv": "^16.4.5",
+        "dotenv": "^17.4.2",
         "isolated-vm": "^5.0.1",
         "ws": "^8.18.0"
       },
@@ -21,8 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.0",
         "@jest/globals": "^30.0.2",
-        "@types/dotenv": "^6.1.1",
-        "@types/node": "^24.0.3",
+        "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
@@ -33,7 +32,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1543,16 +1542,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/dotenv": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
-      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1595,13 +1584,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2942,9 +2931,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -6350,9 +6339,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -59,18 +59,17 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0",
     "@signalk/client": "^2.3.0",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.4.2",
     "isolated-vm": "^5.0.1",
     "ws": "^8.18.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.18.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.0",
     "@jest/globals": "^30.0.2",
-    "@types/dotenv": "^6.1.1",
-    "@types/node": "^24.0.3",
+    "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@
 import * as dotenv from 'dotenv';
 import { SignalKMCPServer } from './signalk-mcp-server.js';
 
-dotenv.config();
+// `quiet: true` suppresses dotenv v17's startup banner so nothing extraneous is
+// written to stdout, which must carry only MCP JSON-RPC frames.
+dotenv.config({ quiet: true });
 
 // Handle unhandled promise rejections gracefully
 process.on('unhandledRejection', (reason, _promise) => {


### PR DESCRIPTION
## What
CI/publish hygiene, safe dependency bumps, and documentation for the modernization. No runtime logic changes beyond the dotenv flag.

## Changes
**CI (`.github/workflows/ci.yml`)**
- Matrix now `20.x` + `22.x` (required) and `24.x` + `25.x` (non-blocking experimental legs) with `fail-fast: false`. Newer Node may lack an `isolated-vm` prebuild — those legs prove the server still **boots** (`execute_code` degrades gracefully) without blocking the build. They promote to required once #6 (optional/lazy `isolated-vm`) lands. Drops EOL Node 18.

**Publish (`.github/workflows/publish-npm.yml`)**
- Replaces the **archived** `actions/create-release@v1` with `softprops/action-gh-release@v3`.
- Bumps `setup-node` to Node 22.

**Dependencies (`package.json`)**
- `dotenv` `^16` → `^17`; removes the deprecated `@types/dotenv` stub (dotenv ships its own types); aligns `@types/node` to `^22`.
- Raises `engines.node` to `>=20.18.0`.

**Runtime (`src/index.ts`)**
- `dotenv.config({ quiet: true })` so dotenv v17's startup banner never writes to **stdout** — which must carry only MCP JSON-RPC frames.

**Docs**
- README, CLAUDE.md, and CHANGELOG document the optional/lazy `isolated-vm` behavior and the **Node 22 LTS** recommendation.

## Verification (Node 22)
- `npm run typecheck` / `build` / `lint` (0 errors) clean; `npm run test:unit` → **131 passed**.
- With a `.env` present, the MCP stdio probe shows **clean JSON-RPC stdout** (no dotenv banner leak); `initialize` + `execute_code` work.
- Both workflow YAML files parse.

## Suggested merge order
This is the documentation/hygiene layer for the set: **#6 (boot fix) → #7 (SDK 1.29) → this**. Lockfiles may need a regenerate when merging the three together.



### CI/publish actions moved onto the Node 24 runtime

GitHub is retiring the Node 20 action runtime, so the actions here are bumped to their Node 24 versions: `actions/checkout@v5`, `actions/setup-node@v5`, `actions/upload-artifact@v6` (note: `v5` is still Node 20), and `softprops/action-gh-release@v3`. This only changes the action runtime, not the Node version the jobs run on. (The two Claude workflows and the `ci-test.yml`/`e2e-tests.yml` files get the same treatment in PR #10.)
