### PR TITLE
Fix the Claude code review workflow and move CI test actions off Node 20

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [20.x]
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v5
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
       run: npm run test:coverage
     
     - name: Upload coverage reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-report
         path: coverage/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,77 +1,42 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Automatic review only runs on same-repo (branch) PRs, because pull_request
+    # does not expose secrets to fork PRs. For a fork PR, a maintainer comments
+    # @claude to request a review (handled by claude.yml).
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write  # Changed to write to allow posting comments
-      issues: read
+      pull-requests: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # Checkout the PR's code
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Post the review as a single PR comment, updated on each push, instead
+          # of only writing to the Actions step summary.
+          track_progress: true
+          use_sticky_comment: true
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            
-            Be constructive and helpful in your feedback.
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
 
+            Be constructive and helpful in your feedback.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,13 +25,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-    
+      uses: actions/checkout@v5
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -65,7 +65,7 @@ jobs:
     
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: e2e-test-results
         path: |


### PR DESCRIPTION
## What this fixes

Two GitHub Actions problems.

### 1. The automatic Claude code review was failing

`claude-code-review.yml` triggered on `pull_request_target`, which the current `claude-code-action` doesn't accept (so every run errored), and it pinned the old `@beta` action with outdated inputs. It was also unsafe: under `pull_request_target` the repo's secrets are in scope, and the workflow checked out the pull request's own code into the workspace - so code from a fork could run with those secrets.

Now it:
- triggers on `pull_request` and only auto-reviews same-repo pull requests (fork PRs can't read secrets); for a fork PR a maintainer comments `@claude`, handled by `claude.yml`,
- drops the unsafe checkout of the PR head and the `github_token` input,
- uses the current action (`@v1`) with the renamed `prompt` input, and
- posts the review as one sticky PR comment.

`claude.yml` (the `@claude` bot) is bumped to the same `@v1` action and `checkout@v5`; its triggers were already fine.

### 2. Node 20 runtime deprecation

GitHub is retiring the Node 20 runtime that older action versions run on. The CI test and end-to-end test workflows now use the Node 24 action versions: `checkout@v5`, `setup-node@v5`, `upload-artifact@v6`. This only changes the action runtime, not the Node version the tests run on.

## Note on ci.yml and publish-npm.yml

Those two files are modernized in the separate open PR (#8). The same Node 24 action bumps for them are added there, so the same files are not edited in two places.

## How it was checked

- Both changed workflow files parse as valid YAML.
- No `pull_request_target`, `@beta`, or Node 20 action pins remain in the changed files.
- Live review behavior can only be confirmed once this is on the base branch: open a same-repo test PR and confirm the review posts a single sticky comment with no "unsupported event type" error or Node 20 warning, and that fork PRs are skipped (use `@claude` there instead).
