### PR TITLE
Add request timeouts/retries and a tool–binding parity guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ docker/signalk-config/*
 # Test results
 test-results/
 
+# Local-only reference: SignalK API specs downloaded from a live server.
+# Kept out of git so no server host / vessel data is ever committed.
+docs/signalk-api-specs/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the SignalK MCP Server project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **SignalK History API support.** Three new SDK functions are available inside `execute_code`:
+  - `getHistory({ paths, from, to, duration, resolution, aggregate, context })` - query aggregated historical time-series for one or more paths.
+  - `listHistoryPaths(options?)` - list paths that have history in a time window.
+  - `listHistoryContexts(options?)` - list vessels that have history.
+- Queries the SignalK v2 History API (`/signalk/v2/api/history/...`) and reshapes the tabular response into easy per-path lists of `{ timestamp, value }` points, so agent code can summarize thousands of rows down to a few numbers inside the isolate.
+- Notes for callers: times are ISO-8601 and `resolution` is in **seconds**; aggregation can be set inline per path (e.g. `navigation.speedOverGround:max`); `navigation.position` history values are `[longitude, latitude]` arrays (unlike the live API's `{latitude, longitude}`); and `null` marks a data gap.
+- Requires a SignalK server with a history provider (e.g. `signalk-to-influxdb`). When none is installed, the functions return `available: false` instead of failing, so code-execution mode keeps working.
+
 ## [1.0.8] - 2025-11-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ const heading = await getPathValue({ path: "navigation.headingTrue" });
 
 // Connection status - ALSO requires await!
 const status = await getConnectionStatus();
+
+// Recorded history over a time range (see "Historical Data" below)
+const past = await getHistory({ paths: 'navigation.speedOverGround', from: '2026-06-11T06:00:00Z', resolution: 300 });
+const historyPaths = await listHistoryPaths();    // which paths have history
 ```
 
 ### Real-time Marine Data
@@ -229,6 +233,136 @@ SERVER_VERSION=1.0.6
 ```
 
 **Result:** ~300 tokens (vs 13,000 with 3 separate tool calls!)
+
+## Historical Data (History API)
+
+The SDK functions above return **live** values. The History API lets the AI look at **recorded** data over time - your track from this morning, how the wind built over the afternoon, how much the batteries drained overnight. As with everything else, the code runs in the isolate, so the AI can boil thousands of recorded points down to a few numbers before any of it reaches the model.
+
+### Requirements
+
+History is recorded by a separate SignalK plugin, so the requirements are on your **SignalK server** (not on this MCP server):
+
+- **SignalK Server 2.15 or newer** (this is where the v2 History API lives).
+- **A history provider plugin that is installed and recording**, most commonly [`signalk-to-influxdb`](https://www.npmjs.com/package/@signalk/signalk-to-influxdb) writing to an InfluxDB database. (`signalk-to-timescaledb` works too.)
+
+If no provider is installed, the history functions still return safely with `available: false` - they never break code execution mode.
+
+### Setup (on the SignalK server)
+
+1. In the SignalK admin web page, open **Appstore → Available** and install **signalk-to-influxdb** (plus an InfluxDB database for it to write to - many boat setups already run one).
+2. Turn the plugin on and let it record for a while so there is some history to query.
+3. Point this MCP server at that SignalK server the usual way (`SIGNALK_HOST` / `SIGNALK_PORT` / `SIGNALK_TLS`). If your server needs a login to read history, set `SIGNALK_TOKEN`.
+
+To check at any time whether history is turned on:
+
+```javascript
+(async () => {
+  const probe = await listHistoryContexts();
+  return JSON.stringify({ historyAvailable: probe.available });
+})()
+```
+
+### History SDK functions
+
+```javascript
+// Query recorded values for one or more paths over a time range
+const h = await getHistory({
+  paths: 'navigation.speedOverGround',  // a path, or an array of paths
+  from: '2026-06-11T06:00:00Z',         // ISO-8601; give "from" or "duration"
+  to:   '2026-06-11T12:00:00Z',         // ISO-8601 (optional, defaults to now)
+  resolution: 300                        // bucket size in SECONDS (300 = 5 min)
+});
+
+// Discover what is recorded
+const paths    = await listHistoryPaths();     // which paths have history
+const contexts = await listHistoryContexts();  // which vessels have history
+```
+
+**Good to know:**
+
+- **Times are ISO-8601** (like `2026-06-11T06:00:00Z`) and **`resolution` is in seconds**, not milliseconds.
+- Pick an **aggregation method per path** by adding it to the path: `'navigation.speedOverGround:max'` or `'environment.wind.speedApparent:sma:5'`. The default is `average` (and `first` for position).
+- `getHistory` returns `{ available, values, series, rowCount }`. `values` is grouped by path, so `values['navigation.speedOverGround']` is a list of `{ timestamp, value }`.
+- **Positions are `[longitude, latitude]` arrays** in history (the live API uses `{ latitude, longitude }`). `null` means there was no data in that bucket - drop nulls before averaging.
+- Always check **`available`** first. `available: false` means no history provider is installed on the server.
+
+### Sample use cases
+
+| Ask | What the code does in the isolate |
+|-----|-----------------------------------|
+| "How far did we sail today, and our average speed while moving?" | Adds up speed over time for distance; ignores time at the dock |
+| "How did the wind build this afternoon?" | Averages wind into short steps and reports the trend and biggest gust |
+| "Show this morning's track" | Pulls position history and thins it down to a handful of waypoints |
+| "How much did the batteries drain overnight?" | Totals battery current over the night into a simple energy summary |
+| "When will we need to refuel?" | Fits a line through tank-level history to estimate burn rate and days left |
+| "Any engine temperature spikes today?" | Scans engine-temp history for spikes and time at high RPM |
+| "What was the roughest weather in the last two days?" | Finds the peak wind and the barometer trend |
+| "The low-battery alarm just fired - what led up to it?" | Pulls the 30 minutes before the alarm and finds where the voltage dropped |
+
+### Example 5: Distance sailed today
+
+**Query:** "How far have we sailed today, and what's our average speed while moving?"
+
+**Code:**
+```javascript
+(async () => {
+  const h = await getHistory({
+    paths: 'navigation.speedOverGround',
+    from: '2026-06-11T00:00:00Z',
+    to:   '2026-06-11T23:59:59Z',
+    resolution: 60                       // 1-minute buckets
+  });
+  if (!h.available) return JSON.stringify({ note: h.error });
+
+  const points = h.values['navigation.speedOverGround'].filter(p => p.value != null);
+
+  let meters = 0, movingMinutes = 0;
+  for (const p of points) {
+    meters += p.value * 60;              // speed (m/s) over a 60s bucket
+    if (p.value > 0.26) movingMinutes++; // moving if faster than ~0.5 knots
+  }
+  const movingHours = movingMinutes / 60;
+
+  return JSON.stringify({
+    distanceNm: (meters / 1852).toFixed(1),
+    movingHours: movingHours.toFixed(1),
+    avgKnotsWhileMoving: movingHours
+      ? ((meters / (movingHours * 3600)) * 1.94384).toFixed(1)
+      : '0'
+  });
+})()
+```
+
+**Result:** A 3-number summary instead of ~1,400 raw speed readings.
+
+### Example 6: This morning's track
+
+**Query:** "Show me the route we took this morning."
+
+**Code:**
+```javascript
+(async () => {
+  const h = await getHistory({
+    paths: 'navigation.position',        // recorded as [longitude, latitude]
+    from: '2026-06-11T06:00:00Z',
+    to:   '2026-06-11T12:00:00Z',
+    resolution: 120                      // a fix every 2 minutes
+  });
+  if (!h.available) return JSON.stringify({ note: h.error });
+
+  const track = h.values['navigation.position']
+    .filter(p => p.value != null)
+    .map(p => ({ lon: p.value[0], lat: p.value[1], time: p.timestamp })); // [lon, lat]!
+
+  return JSON.stringify({
+    fixes: track.length,
+    start: track[0],
+    end: track[track.length - 1]
+  });
+})()
+```
+
+**Result:** A short list of waypoints instead of thousands of position fixes.
 
 ## Development
 

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -65,6 +65,33 @@
         "note": "This function is also async - MUST use await",
         "returns": "Object with connected, url, hostname, port, context, timestamp",
         "example": "const status = await getConnectionStatus();\nconsole.log('Connected:', status.connected);"
+      },
+      "getHistory": {
+        "signature": "await getHistory({ paths, from, to, duration, resolution, aggregate, context })",
+        "description": "Query aggregated historical time-series for one or more SignalK paths. Requires a SignalK history provider (e.g. signalk-to-influxdb).",
+        "parameters": {
+          "paths": "Path string or array of paths; add an inline aggregation method as path:method[:param], e.g. 'navigation.speedOverGround:sma:5'",
+          "from": "ISO-8601 start time; provide 'from' or 'duration'",
+          "to": "ISO-8601 end time (defaults to now)",
+          "duration": "ISO-8601 duration (PT1H) or seconds; use instead of 'from'",
+          "resolution": "Bucket size in SECONDS (not milliseconds), e.g. 60 for 1-minute buckets",
+          "aggregate": "Default method for bare paths: average|min|max|first|last (default average)",
+          "context": "Vessel context (default vessels.self)"
+        },
+        "returns": "{ available, values: { '<path>': [{ timestamp, value }] }, series, missingPaths, rowCount }. Check 'available' (false = no history provider). null marks a data gap. navigation.position values are [longitude, latitude] ARRAYS, unlike live getVesselState which uses {latitude, longitude}.",
+        "example": "(async () => {\n  const h = await getHistory({ paths: 'navigation.speedOverGround:max', from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300 });\n  if (!h.available) return JSON.stringify({ note: h.error });\n  const pts = h.values['navigation.speedOverGround'].filter(p => p.value != null);\n  return JSON.stringify({ maxKn: (Math.max(...pts.map(p => p.value)) * 1.94384).toFixed(1) });\n})()"
+      },
+      "listHistoryPaths": {
+        "signature": "await listHistoryPaths(options?)",
+        "description": "List SignalK paths that have historical data in a time window. Defaults to the last 24 hours.",
+        "returns": "{ available, count, paths: string[] }. available:false means no history provider.",
+        "example": "const h = await listHistoryPaths();\nif (h.available) console.log(h.paths.length, 'historized paths');"
+      },
+      "listHistoryContexts": {
+        "signature": "await listHistoryContexts(options?)",
+        "description": "List vessel contexts that have historical data. Call before get_history to discover which vessels have history.",
+        "returns": "{ available, count, contexts: string[] }",
+        "example": "const h = await listHistoryContexts();\nif (h.available) console.log(h.contexts);"
       }
     }
   },
@@ -116,7 +143,11 @@
     "units": "All SignalK values use SI units (meters, seconds, Kelvin, radians)",
     "timestamps": "All data includes RFC 3339 timestamps for freshness checking",
     "missing_data": "Paths may not exist if sensors/systems not installed",
-    "null_values": "Null values indicate sensor offline or no valid reading"
+    "null_values": "Null values indicate sensor offline or no valid reading",
+    "history_times": "History query times are ISO-8601 only; resolution is in SECONDS (not milliseconds)",
+    "history_positions": "In history results, navigation.position is a [longitude, latitude] array - NOT the {latitude, longitude} object that live getVesselState/getPathValue return",
+    "history_gaps": "In history results, null marks a time bucket with no data - filter nulls before averaging or integrating",
+    "history_availability": "get_history/list_history_* return available:false when the SignalK server has no history provider installed"
   },
   "legacy_tools": {
     "status": "DEPRECATED - Available only in 'tools' or 'hybrid' mode",

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -6,6 +6,10 @@ import type {
   AvailablePathsResponse,
   PathValueResponse,
   ConnectionStatus,
+  HistoryQueryOptions,
+  HistoryResponse,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from '../types/index.js';
 
 /**
@@ -173,6 +177,53 @@ export class SignalKBinding {
   async getPathValue(pathOrOptions: string | { path: string }): Promise<PathValueResponse> {
     const path = typeof pathOrOptions === 'string' ? pathOrOptions : pathOrOptions.path;
     return this.client.getPathValue(path);
+  }
+
+  /**
+   * Query historical time-series for one or more SignalK paths.
+   *
+   * Requires a SignalK server with a history provider (e.g. signalk-to-influxdb).
+   * Returns per-path arrays of { timestamp, value }. All times are ISO-8601 and
+   * `resolution` is in SECONDS. navigation.position values are [lon, lat] arrays.
+   * Check `available` - it is false when no history provider is installed.
+   *
+   * @example
+   * // In agent code
+   * const h = await signalk.getHistory({
+   *   paths: 'navigation.speedOverGround:max',
+   *   from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300
+   * });
+   * if (h.available) {
+   *   const sog = h.values['navigation.speedOverGround'].filter(p => p.value != null);
+   * }
+   */
+  async getHistory(options: HistoryQueryOptions): Promise<HistoryResponse> {
+    return this.client.getHistory(options);
+  }
+
+  /**
+   * List SignalK paths that have historical data in a time window.
+   * @returns HistoryPathsResponse; available:false means no history provider
+   */
+  async listHistoryPaths(options?: {
+    from?: string;
+    to?: string;
+    duration?: string | number;
+    context?: string;
+  }): Promise<HistoryPathsResponse> {
+    return this.client.listHistoryPaths(options);
+  }
+
+  /**
+   * List vessel contexts that have historical data in a time window.
+   * @returns HistoryContextsResponse; available:false means no history provider
+   */
+  async listHistoryContexts(options?: {
+    from?: string;
+    to?: string;
+    duration?: string | number;
+  }): Promise<HistoryContextsResponse> {
+    return this.client.listHistoryContexts(options);
   }
 
   /**

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1949,6 +1949,43 @@ describe('SignalKClient', () => {
     });
   });
 
+  describe('Request reliability (timeout + retry)', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    test('a hung server times out gracefully instead of stalling the call', async () => {
+      jest.useFakeTimers();
+      try {
+        // The server "hangs": fetch only settles if its request is aborted.
+        mockFetch.mockImplementation(
+          (_url: any, init: any) =>
+            new Promise((_resolve, reject) => {
+              const signal = (init && init.signal) as AbortSignal | undefined;
+              signal?.addEventListener('abort', () =>
+                reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+              );
+            }) as any,
+        );
+
+        const pending = client.listAvailablePaths();
+        // Drive the initial timeout and the one retry.
+        await jest.advanceTimersByTimeAsync(60000);
+        const res = await pending;
+
+        expect(res.connected).toBe(false);
+        expect(typeof res.error).toBe('string');
+        expect(res.error).toMatch(/tim(e|ed)\s?out|failed/i);
+      } finally {
+        jest.useRealTimers();
+      }
+    }, 15000);
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1948,4 +1948,268 @@ describe('SignalKClient', () => {
       expect((client as any).shouldIncludeAISPath('unknown.path')).toBe(false);
     });
   });
+
+  describe('History Methods', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    // A small real-shaped fixture: two columns (a scalar + a position) and a
+    // null gap in the last row.
+    const valuesFixture = {
+      context: 'vessels.self',
+      range: { from: '2026-06-11T06:00:00.000Z', to: '2026-06-11T06:10:00.000Z' },
+      values: [
+        { path: 'navigation.speedOverGround', method: 'max' },
+        { path: 'navigation.position', method: 'first' },
+      ],
+      data: [
+        ['2026-06-11T06:00:00.000Z', 3.14, [-122.47, 37.81]],
+        ['2026-06-11T06:05:00.000Z', 0, [-122.48, 37.82]],
+        ['2026-06-11T06:10:00.000Z', null, null],
+      ],
+    };
+
+    const okJson = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const errResp = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve('boom'),
+      } as Response);
+
+    describe('buildHistoryApiUrl', () => {
+      test('targets the v2 history base and drops undefined params', () => {
+        const url = client.buildHistoryApiUrl('values', {
+          context: 'vessels.self',
+          paths: 'navigation.speedOverGround:max',
+          from: '2026-06-11T06:00:00Z',
+          to: undefined,
+          resolution: 60,
+        });
+        expect(
+          url.startsWith('http://example.com:3000/signalk/v2/api/history/values?'),
+        ).toBe(true);
+        const decoded = decodeURIComponent(url);
+        expect(decoded).toContain('paths=navigation.speedOverGround:max');
+        expect(decoded).toContain('from=2026-06-11T06:00:00Z');
+        expect(decoded).toContain('resolution=60'); // seconds, not ms
+        expect(url).not.toContain('to='); // undefined dropped
+      });
+    });
+
+    describe('getHistory transform', () => {
+      test('maps each response column to its path by index, keeping nulls and [lon,lat]', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        const h = await client.getHistory({
+          paths: ['navigation.speedOverGround:max', 'navigation.position:first'],
+          from: '2026-06-11T06:00:00Z',
+          to: '2026-06-11T06:10:00Z',
+          resolution: 300,
+        });
+        expect(h.available).toBe(true);
+        expect(h.rowCount).toBe(3);
+        const sog = h.values['navigation.speedOverGround'];
+        expect(sog.map((p) => p.value)).toEqual([3.14, 0, null]); // 0 kept, null strict
+        const pos = h.values['navigation.position'];
+        expect(pos[0].value).toEqual([-122.47, 37.81]); // array passthrough
+        expect(pos[2].value).toBeNull();
+        expect(h.series).toHaveLength(2);
+        expect(h.series[1].method).toBe('first');
+        expect(h.missingPaths).toEqual([]);
+      });
+
+      test('keys by RESPONSE order, not request order', async () => {
+        const shuffled = {
+          ...valuesFixture,
+          values: [
+            { path: 'navigation.position', method: 'first' },
+            { path: 'navigation.speedOverGround', method: 'max' },
+          ],
+          data: [['2026-06-11T06:00:00.000Z', [-1, 2], 9.9]],
+        };
+        mockFetch.mockResolvedValueOnce(okJson(shuffled));
+        const h = await client.getHistory({
+          paths: ['navigation.speedOverGround', 'navigation.position'],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.values['navigation.position'][0].value).toEqual([-1, 2]);
+        expect(h.values['navigation.speedOverGround'][0].value).toBe(9.9);
+      });
+
+      test('keeps duplicate paths in series and reports missing paths', async () => {
+        const dup = {
+          context: 'vessels.self',
+          range: { from: 'a', to: 'b' },
+          values: [
+            { path: 'navigation.speedOverGround', method: 'max' },
+            { path: 'navigation.speedOverGround', method: 'min' },
+          ],
+          data: [['t', 5, 1]],
+        };
+        mockFetch.mockResolvedValueOnce(okJson(dup));
+        const h = await client.getHistory({
+          paths: [
+            'navigation.speedOverGround:max',
+            'navigation.speedOverGround:min',
+            'tanks.fuel.level',
+          ],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.series).toHaveLength(2);
+        expect(h.series[0].method).toBe('max');
+        expect(h.series[1].method).toBe('min');
+        // values map keyed by bare path - last (min) wins
+        expect(h.values['navigation.speedOverGround'][0].value).toBe(1);
+        expect(h.missingPaths).toContain('tanks.fuel.level');
+      });
+
+      test('empty data window is available:true with rowCount 0 (not unavailable)', async () => {
+        mockFetch.mockResolvedValueOnce(
+          okJson({
+            context: 'vessels.self',
+            range: { from: 'a', to: 'b' },
+            values: [{ path: 'navigation.speedOverGround', method: 'average' }],
+            data: [],
+          }),
+        );
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.rowCount).toBe(0);
+        expect(h.values['navigation.speedOverGround']).toEqual([]);
+      });
+    });
+
+    describe('paths composition', () => {
+      test('applies default aggregate to bare paths but not to inline or position', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: [
+            'navigation.speedOverGround',
+            'environment.wind.speedApparent:sma:5',
+            'navigation.position',
+          ],
+          aggregate: 'max',
+          from: '2026-06-11T06:00:00Z',
+        });
+        const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        expect(url).toContain(
+          'paths=navigation.speedOverGround:max,environment.wind.speedApparent:sma:5,navigation.position',
+        );
+      });
+
+      test('string and array paths produce the same request', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: 'navigation.speedOverGround:max',
+          from: '2026-06-11T06:00:00Z',
+        });
+        const a = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: ['navigation.speedOverGround:max'],
+          from: '2026-06-11T06:00:00Z',
+        });
+        const b = decodeURIComponent(mockFetch.mock.calls[1][0] as string);
+        expect(a).toBe(b);
+      });
+    });
+
+    describe('input guards (no request sent)', () => {
+      test('missing from and duration => available:true with a clear error, no fetch', async () => {
+        const h = await client.getHistory({ paths: 'navigation.speedOverGround' });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/from.*duration/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+      test('non-ISO from => distinct error, no fetch', async () => {
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: 'yesterday',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/ISO-8601/);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+      test('no paths => clear error, no fetch', async () => {
+        const h = await client.getHistory({
+          paths: [],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/path/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('graceful degradation (never throws, no cache fallback)', () => {
+      test('404 => available:false (no provider)', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(404));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(false);
+        expect(h.values).toEqual({});
+        expect(h.error).toMatch(/not available|provider/i);
+      });
+      test('400 => available:true with invalid-query error', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(400));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/invalid/i);
+      });
+      test('401 => available:true asking for auth', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(401));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/auth|SIGNALK_TOKEN/i);
+      });
+      test('network error => available:false, no throw', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('network down'));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(false);
+        expect(h.values).toEqual({});
+      });
+    });
+
+    describe('listHistoryPaths / listHistoryContexts', () => {
+      test('parse a JSON array of strings and default to a 24h window', async () => {
+        mockFetch.mockResolvedValueOnce(
+          okJson(['navigation.position', 'electrical.batteries.house.voltage']),
+        );
+        const r = await client.listHistoryPaths();
+        expect(r.available).toBe(true);
+        expect(r.count).toBe(2);
+        expect(r.paths).toContain('navigation.position');
+        const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        expect(url).toContain('/signalk/v2/api/history/paths');
+        expect(url).toContain('duration=PT24H');
+      });
+      test('contexts 404 => available:false', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(404));
+        const r = await client.listHistoryContexts();
+        expect(r.available).toBe(false);
+        expect(r.contexts).toEqual([]);
+      });
+    });
+  });
 });

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -871,7 +871,8 @@ describe('SignalKClient', () => {
       expect(client.connected).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/signalk/v1/api/vessels/self'),
-        {}, // buildFetchOptions() returns empty object when no token
+        // fetchJson now attaches an AbortController signal for the timeout.
+        expect.objectContaining({ signal: expect.anything() }),
       );
     });
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -143,6 +143,34 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * Build a SignalK v2 History API URL.
+   *
+   * The History API lives at /signalk/v2/api/history/<endpoint> - a different
+   * base path from buildRestApiUrl (/signalk/v1/api/vessels/...). Query values
+   * that are undefined or empty are dropped. Reserved characters in the path
+   * expression (':' and ',') are percent-encoded by URLSearchParams and decoded
+   * by the server before it splits them.
+   *
+   * @param endpoint - 'values', 'contexts', or 'paths'
+   * @param params - query parameters; undefined/empty values are omitted
+   * @returns Complete History API URL
+   */
+  buildHistoryApiUrl(
+    endpoint: 'values' | 'contexts' | 'paths',
+    params: Record<string, string | number | undefined> = {},
+  ): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        query.set(key, String(value));
+      }
+    }
+    const queryString = query.toString();
+    const suffix = queryString ? `?${queryString}` : '';
+    return `${this.buildHttpUrl()}/signalk/v2/api/history/${endpoint}${suffix}`;
+  }
+
+  /**
    * Build fetch options with authentication headers if token is configured
    * @returns RequestInit object with authorization header if token exists
    */

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -191,6 +191,49 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * fetch() wrapped with an AbortController timeout and one bounded retry, so a
+   * hung or flaky SignalK server fails fast and legibly instead of stalling a
+   * tool call. Auth headers (buildFetchOptions) are applied automatically.
+   * Returns the Response; callers handle response.ok / .json() as before.
+   */
+  private async fetchJson(
+    url: string,
+    init: RequestInit = {},
+    opts: { timeoutMs?: number; retries?: number } = {},
+  ): Promise<Response> {
+    const timeoutMs = opts.timeoutMs ?? 10000;
+    const retries = opts.retries ?? 1;
+    const base = this.buildFetchOptions();
+
+    let lastError: any;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        return await fetch(url, {
+          ...base,
+          ...init,
+          headers: { ...(base.headers as any), ...(init.headers as any) },
+          signal: controller.signal,
+        });
+      } catch (error: any) {
+        const aborted = error?.name === 'AbortError';
+        lastError = aborted
+          ? new Error(`Request timed out after ${timeoutMs}ms`)
+          : error;
+        // Retry once on a timeout only; a hard network/parse error fails fast.
+        if (!aborted || attempt >= retries) {
+          throw lastError;
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    // Unreachable (the loop either returns or throws), satisfies the type checker.
+    throw lastError;
+  }
+
+  /**
    * Sets up WebSocket event handlers for connection, disconnection, errors, and delta messages
    *
    * Event handlers:
@@ -254,7 +297,7 @@ export class SignalKClient extends EventEmitter {
     // Test HTTP connectivity
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -320,7 +363,7 @@ export class SignalKClient extends EventEmitter {
   private async fetchInitialVesselState(): Promise<void> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -626,7 +669,7 @@ export class SignalKClient extends EventEmitter {
   async getVesselState(): Promise<VesselState> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -839,7 +882,7 @@ export class SignalKClient extends EventEmitter {
 
       // Fetch all vessels from the API
       const apiUrl = `${this.buildHttpUrl()}/signalk/v1/api/vessels`;
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1034,7 +1077,7 @@ export class SignalKClient extends EventEmitter {
   async getActiveAlarms(): Promise<ActiveAlarmsResponse> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1133,7 +1176,7 @@ export class SignalKClient extends EventEmitter {
       // Use helper method to build REST API URL
       const apiUrl = this.buildRestApiUrl('self');
 
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -1236,7 +1279,7 @@ export class SignalKClient extends EventEmitter {
       // Use helper method to build REST API URL for the specific path
       const apiUrl = this.buildRestApiUrl('self', path);
 
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -1335,7 +1378,7 @@ export class SignalKClient extends EventEmitter {
     });
 
     try {
-      const response = await fetch(url, this.buildFetchOptions());
+      const response = await this.fetchJson(url);
       if (!response.ok) {
         const detail = await response.text().catch(() => '');
         const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
@@ -1539,7 +1582,7 @@ export class SignalKClient extends EventEmitter {
     });
 
     try {
-      const response = await fetch(url, this.buildFetchOptions());
+      const response = await this.fetchJson(url);
       if (!response.ok) {
         const detail = await response.text().catch(() => '');
         const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -12,6 +12,12 @@ import type {
   ConnectionStatus,
   AvailablePathsResponse,
   PathValueResponse,
+  HistoryQueryOptions,
+  HistoryResponse,
+  HistorySeries,
+  HistoryDataPoint,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -1257,6 +1263,295 @@ export class SignalKClient extends EventEmitter {
         timestamp: new Date().toISOString(),
         error: `HTTP fetch failed: ${error.message}, using cached value`,
       };
+    }
+  }
+
+  /**
+   * Query aggregated historical time-series for one or more SignalK paths.
+   *
+   * Hits the SignalK v2 History API (/signalk/v2/api/history/values) and folds
+   * its tabular response into per-path series. Unlike getPathValue there is NO
+   * cache fallback - history has no live cache. The method never throws; it
+   * always returns a HistoryResponse whose `available` flag tells callers
+   * whether a history provider answered.
+   *
+   * @param options - paths plus a time window (from/to or duration), resolution
+   *                  in SECONDS, optional default aggregate, and context
+   * @returns HistoryResponse with `series` (one entry per response column) and a
+   *          convenience `values` map keyed by path
+   */
+  async getHistory(options: HistoryQueryOptions): Promise<HistoryResponse> {
+    // Normalize and coerce paths to strings up front so stray non-string input
+    // from untyped isolate code can never throw before the request is built.
+    const rawPaths = Array.isArray(options?.paths) ? options.paths : [options?.paths];
+    const requestedPaths = rawPaths
+      .filter((p) => p !== undefined && p !== null)
+      .map((p) => String(p));
+
+    const empty = (available: boolean, error?: string): HistoryResponse => ({
+      available,
+      connected: this.connected,
+      resolution: options?.resolution,
+      requestedPaths,
+      series: [],
+      values: {},
+      missingPaths: requestedPaths.map((p) => p.split(':')[0]),
+      timestamp: new Date().toISOString(),
+      ...(error ? { error } : {}),
+    });
+
+    if (requestedPaths.length === 0) {
+      return empty(true, 'Invalid history query: at least one path is required');
+    }
+
+    // Validate the time window. The server requires at least one of `from` or
+    // `duration`; a missing/`to`-only window or a non-ISO time is a client
+    // error, reported distinctly from a missing provider and without a request.
+    const from = this.normalizeIso(options.from);
+    if (options.from !== undefined && from === undefined) {
+      return empty(true, 'Invalid history query: "from" must be an ISO-8601 time (e.g. 2026-06-11T06:00:00Z)');
+    }
+    const to = this.normalizeIso(options.to);
+    if (options.to !== undefined && to === undefined) {
+      return empty(true, 'Invalid history query: "to" must be an ISO-8601 time (e.g. 2026-06-11T12:00:00Z)');
+    }
+    const duration = options.duration !== undefined ? String(options.duration) : undefined;
+    if (from === undefined && duration === undefined) {
+      return empty(true, 'Invalid history query: provide "from" or "duration"');
+    }
+
+    const pathsParam = requestedPaths
+      .map((p) => this.composeHistoryPath(p, options.aggregate))
+      .join(',');
+
+    const url = this.buildHistoryApiUrl('values', {
+      context: options.context ?? this.context,
+      paths: pathsParam,
+      from,
+      to,
+      duration,
+      resolution: options.resolution,
+      provider: options.provider,
+    });
+
+    try {
+      const response = await fetch(url, this.buildFetchOptions());
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
+        return empty(available, error);
+      }
+      const body: any = await response.json();
+      return this.transformHistoryValues(body, requestedPaths, options.resolution);
+    } catch (error: any) {
+      console.error('Failed to fetch history values via HTTP:', error.message);
+      const { available, error: message } = this.classifyHistoryFailure(undefined, error?.message || String(error));
+      return empty(available, message);
+    }
+  }
+
+  /**
+   * List SignalK paths that have historical data in a time window.
+   * @returns HistoryPathsResponse; `available:false` means no history provider
+   */
+  async listHistoryPaths(
+    options: { from?: string; to?: string; duration?: string | number; context?: string } = {},
+  ): Promise<HistoryPathsResponse> {
+    const r = await this.fetchHistoryStringList('paths', options);
+    return {
+      available: r.available,
+      connected: this.connected,
+      count: r.items.length,
+      paths: r.items,
+      timestamp: new Date().toISOString(),
+      ...(r.error ? { error: r.error } : {}),
+    };
+  }
+
+  /**
+   * List vessel contexts that have historical data in a time window.
+   * @returns HistoryContextsResponse; `available:false` means no history provider
+   */
+  async listHistoryContexts(
+    options: { from?: string; to?: string; duration?: string | number } = {},
+  ): Promise<HistoryContextsResponse> {
+    const r = await this.fetchHistoryStringList('contexts', options);
+    return {
+      available: r.available,
+      connected: this.connected,
+      count: r.items.length,
+      contexts: r.items,
+      timestamp: new Date().toISOString(),
+      ...(r.error ? { error: r.error } : {}),
+    };
+  }
+
+  /**
+   * Build one entry of the comma-separated `paths` param. A path may already
+   * carry an inline aggregation method (path:method[:param]); if so it is left
+   * untouched. Otherwise an optional default `aggregate` is applied - but never
+   * to navigation.position (the server aggregates positions with "first").
+   */
+  private composeHistoryPath(pathExpr: string, aggregate?: string): string {
+    const hasInlineMethod = pathExpr.split(':').length >= 2;
+    if (hasInlineMethod || !aggregate) {
+      return pathExpr;
+    }
+    if (pathExpr === 'navigation.position') {
+      return pathExpr;
+    }
+    return `${pathExpr}:${aggregate}`;
+  }
+
+  /**
+   * Coerce a time input to an ISO-8601 string. Accepts a Date or epoch-ms
+   * number; passes a valid ISO-ish string through; returns undefined for input
+   * that cannot be a real instant (so the caller can report a clear error).
+   */
+  private normalizeIso(value: unknown): string | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      return isNaN(value.getTime()) ? undefined : value.toISOString();
+    }
+    if (typeof value === 'number') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? undefined : d.toISOString();
+    }
+    if (typeof value === 'string') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? undefined : value;
+    }
+    return undefined;
+  }
+
+  /**
+   * Map an HTTP status (or network error) to history availability + message.
+   * 404/501 or a network error means no provider is installed (available:false).
+   * 400/422 means the provider exists but the request was bad (available:true).
+   * 401/403 means the provider exists but needs auth (available:true).
+   */
+  private classifyHistoryFailure(
+    status: number | undefined,
+    detail: string,
+  ): { available: boolean; error: string } {
+    const suffix = detail ? `: ${detail}` : '';
+    if (status === 404 || status === 501) {
+      return {
+        available: false,
+        error: `History API not available - no history provider installed on the SignalK server (HTTP ${status})`,
+      };
+    }
+    if (status === 400 || status === 422) {
+      return { available: true, error: `Invalid history query (HTTP ${status})${suffix}` };
+    }
+    if (status === 401 || status === 403) {
+      return {
+        available: true,
+        error: `History API requires authentication - set SIGNALK_TOKEN (HTTP ${status})`,
+      };
+    }
+    return {
+      available: false,
+      error: `History API request failed${status ? ` (HTTP ${status})` : ''}${suffix}`,
+    };
+  }
+
+  /**
+   * Convert the server's tabular history response into per-path series. The
+   * response `values` array is authoritative: column i+1 of each data row maps
+   * to values[i].path. We iterate the response columns (never the request) so
+   * reordered, duplicate, or absent paths are handled correctly.
+   */
+  private transformHistoryValues(
+    body: any,
+    requestedPaths: string[],
+    resolution?: number,
+  ): HistoryResponse {
+    const columns: Array<{ path: string; method: string }> = Array.isArray(body?.values)
+      ? body.values
+      : [];
+    const rows: any[][] = Array.isArray(body?.data) ? body.data : [];
+
+    const series: HistorySeries[] = columns.map((col, i) => ({
+      path: col?.path,
+      method: col?.method,
+      points: rows.map(
+        (row): HistoryDataPoint => ({
+          timestamp: row?.[0],
+          value: row?.[i + 1] ?? null,
+        }),
+      ),
+    }));
+
+    // Convenience map keyed by path; the last method wins on duplicate paths
+    // (use `series` to keep every column).
+    const values: Record<string, HistoryDataPoint[]> = {};
+    for (const s of series) {
+      values[s.path] = s.points;
+    }
+
+    const returnedPaths = new Set(columns.map((c) => c?.path));
+    const missingPaths = requestedPaths
+      .map((p) => p.split(':')[0])
+      .filter((p) => !returnedPaths.has(p));
+
+    return {
+      available: true,
+      connected: this.connected,
+      context: body?.context,
+      range: body?.range,
+      resolution,
+      requestedPaths,
+      series,
+      values,
+      missingPaths,
+      rowCount: rows.length,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Shared fetch + degradation handling for the history list endpoints
+   * (paths/contexts), which both return a JSON array of strings.
+   */
+  private async fetchHistoryStringList(
+    endpoint: 'paths' | 'contexts',
+    options: { from?: string; to?: string; duration?: string | number; context?: string },
+  ): Promise<{ available: boolean; items: string[]; error?: string }> {
+    const from = this.normalizeIso(options.from);
+    const to = this.normalizeIso(options.to);
+    // The list endpoints scope to a time window; default to the last 24h when
+    // the caller gives neither `from` nor `duration` so the result is not empty.
+    const duration =
+      options.duration !== undefined
+        ? String(options.duration)
+        : from === undefined
+          ? 'PT24H'
+          : undefined;
+
+    const url = this.buildHistoryApiUrl(endpoint, {
+      context: options.context,
+      from,
+      to,
+      duration,
+    });
+
+    try {
+      const response = await fetch(url, this.buildFetchOptions());
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
+        return { available, items: [], error };
+      }
+      const body: any = await response.json();
+      const items: string[] = Array.isArray(body) ? body : [];
+      return { available: true, items };
+    } catch (error: any) {
+      console.error(`Failed to fetch history ${endpoint} via HTTP:`, error.message);
+      const { available, error: message } = this.classifyHistoryFailure(undefined, error?.message || String(error));
+      return { available, items: [], error: message };
     }
   }
 

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,13 +270,16 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(7);
+      expect(result.tools).toHaveLength(10);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
         'get_active_alarms',
         'list_available_paths',
         'get_path_value',
+        'get_history',
+        'list_history_paths',
+        'list_history_contexts',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -374,6 +374,94 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_history',
+        description:
+          'Query aggregated historical time-series for one or more SignalK paths. ' +
+          'Requires a SignalK server with a history provider (e.g. signalk-to-influxdb); ' +
+          'if none is installed the result has available:false. ' +
+          'Times are ISO-8601 (e.g. 2026-06-11T06:00:00Z); resolution is in SECONDS; ' +
+          'provide "from" or "duration". Aggregation can be set inline per path ' +
+          '(e.g. "navigation.speedOverGround:max"). Returns a per-path map of ' +
+          '{timestamp, value} points; navigation.position values are [longitude, latitude] ' +
+          'arrays (NOT {latitude, longitude}), and null marks a gap. Best used inside ' +
+          'execute_code so you can aggregate before returning.\n\n' +
+          'Example:\n' +
+          '```javascript\n' +
+          '(async () => {\n' +
+          "  const h = await getHistory({ paths: 'navigation.speedOverGround:max', from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300 });\n" +
+          '  if (!h.available) return JSON.stringify({ note: h.error });\n' +
+          "  const pts = h.values['navigation.speedOverGround'].filter(p => p.value != null);\n" +
+          '  return JSON.stringify({ maxKn: (Math.max(...pts.map(p => p.value)) * 1.94384).toFixed(1) });\n' +
+          '})();\n' +
+          '```',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            paths: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'SignalK path(s), optionally with an inline aggregation method (path:method[:param]), ' +
+                'e.g. ["navigation.speedOverGround:sma:5", "navigation.position"]',
+            },
+            from: {
+              type: 'string',
+              description: 'ISO-8601 start time (provide "from" or "duration")',
+            },
+            to: { type: 'string', description: 'ISO-8601 end time (defaults to now)' },
+            duration: {
+              type: 'string',
+              description: 'ISO-8601 duration (PT1H) or seconds; use instead of "from"',
+            },
+            resolution: {
+              type: 'number',
+              description: 'Bucket size in SECONDS (e.g. 60 = 1-minute buckets)',
+            },
+            aggregate: {
+              type: 'string',
+              description:
+                'Default aggregation for bare paths: average|min|max|first|last (default average)',
+            },
+            context: { type: 'string', description: 'Vessel context (default vessels.self)' },
+          },
+          required: ['paths'],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'list_history_paths',
+        description:
+          'List SignalK paths that have historical data in a time window. ' +
+          'Returns available:false when no history provider is installed. ' +
+          'Defaults to the last 24 hours when no time window is given.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'ISO-8601 start time' },
+            to: { type: 'string', description: 'ISO-8601 end time' },
+            duration: { type: 'string', description: 'ISO-8601 duration (P1D) or seconds' },
+            context: { type: 'string', description: 'Vessel context filter' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'list_history_contexts',
+        description:
+          'List vessel contexts that have historical data in a time window. ' +
+          'Returns available:false when no history provider is installed. ' +
+          'Useful to discover which vessels have history before calling get_history.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'ISO-8601 start time' },
+            to: { type: 'string', description: 'ISO-8601 end time' },
+            duration: { type: 'string', description: 'ISO-8601 duration (P1D) or seconds' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -449,7 +537,9 @@ export class SignalKMCPServer {
             'Execute JavaScript code in a secure V8 isolate with access to SignalK SDK functions. ' +
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
-            'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(). ' +
+            'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options). ' +
+            'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
           inputSchema: {
@@ -523,7 +613,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts()`,
               );
           }
         } catch (error: any) {

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -474,6 +474,9 @@ describe('Tool Migration Tests', () => {
             'execute_code',
             'get_initial_context',
             'get_connection_status',
+            'get_history',
+            'list_history_paths',
+            'list_history_contexts',
           ].includes(t.name)
       );
 

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -85,6 +85,7 @@ jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
 
 import { SignalKMCPServer } from './signalk-mcp-server.js';
 import { SignalKClient } from './signalk-client.js';
+import { SignalKBinding } from './bindings/signalk-binding.js';
 
 // Mock the SignalK client
 jest.mock('./signalk-client', () => ({
@@ -553,6 +554,35 @@ describe('Tool Migration Tests', () => {
 
       // Should be valid async IIFE pattern
       expect(code.trim().endsWith('})();')).toBe(true);
+    });
+  });
+
+  describe('Tool/binding parity', () => {
+    // Direct-only utility tools: handled by the server, not exposed inside the
+    // isolate as SDK functions that call the binding.
+    const DIRECT_ONLY = ['execute_code', 'get_initial_context'];
+    const toCamelCase = (s: string): string =>
+      s.replace(/_([a-z])/g, (_m: string, c: string) => c.toUpperCase());
+
+    it('every tool definition has a matching camelCase method on SignalKBinding', () => {
+      new SignalKMCPServer({ executionMode: 'hybrid' });
+      const listToolsHandler = mockServer.setRequestHandler.mock.calls.find(
+        (call) => call[0] === 'ListToolsRequestSchema'
+      )?.[1] as any;
+      const tools = listToolsHandler().tools as Array<{ name: string }>;
+
+      const bindingMethods = Object.getOwnPropertyNames(
+        SignalKBinding.prototype
+      );
+      const missing = tools
+        .map((t) => t.name)
+        .filter((name) => !DIRECT_ONLY.includes(name))
+        .filter((name) => !bindingMethods.includes(toCamelCase(name)));
+
+      // The isolate SDK is auto-generated from tool names via the same
+      // camelCase rule (generator.ts); a tool without a matching binding method
+      // would be a broken SDK function inside execute_code.
+      expect(missing).toEqual([]);
     });
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,12 @@ export type {
   AvailablePathsResponse,
   PathValueResponse,
   ConnectionStatus,
+  HistoryDataPoint,
+  HistoryQueryOptions,
+  HistorySeries,
+  HistoryResponse,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -80,3 +80,77 @@ export interface PathValueResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface HistoryDataPoint {
+  timestamp: string;
+  // Aggregated value for one time bucket. May be a scalar (number / string /
+  // boolean), a position [longitude, latitude] array (GeoJSON order, unlike the
+  // live API's {latitude, longitude}), or null for a gap with no data.
+  value: number | number[] | string | boolean | null;
+}
+
+export interface HistoryQueryOptions {
+  // One or more SignalK paths. Each entry may include an inline aggregation
+  // method: 'path', 'path:method', or 'path:method:param'
+  // (e.g. 'navigation.speedOverGround:sma:5').
+  paths: string | string[];
+  // ISO-8601 start time. At least one of `from` or `duration` is required.
+  from?: string;
+  // ISO-8601 end time (defaults to now on the server).
+  to?: string;
+  // ISO-8601 duration ('PT1H') or whole seconds; use instead of `from`/`to`.
+  duration?: string | number;
+  // Bucket size in SECONDS (not milliseconds).
+  resolution?: number;
+  // Default aggregation method applied to bare paths (e.g. 'average', 'max').
+  aggregate?: string;
+  // Vessel context (default 'vessels.self').
+  context?: string;
+  // Optional history provider id (e.g. 'signalk-to-influxdb2').
+  provider?: string;
+}
+
+export interface HistorySeries {
+  path: string;
+  method: string;
+  points: HistoryDataPoint[];
+}
+
+export interface HistoryResponse {
+  // True when the history provider answered (even if the window was empty).
+  // False only when no history provider is installed/reachable.
+  available: boolean;
+  connected: boolean;
+  context?: string;
+  range?: { from: string; to: string };
+  resolution?: number;
+  requestedPaths: string[];
+  // One entry per response column, in server order (never lossy).
+  series: HistorySeries[];
+  // Convenience map keyed by path. If the same path is requested with two
+  // methods, the last one wins here - use `series` to keep both.
+  values: Record<string, HistoryDataPoint[]>;
+  // Requested paths the server returned no column for.
+  missingPaths: string[];
+  rowCount?: number;
+  timestamp: string;
+  error?: string;
+}
+
+export interface HistoryPathsResponse {
+  available: boolean;
+  connected: boolean;
+  count: number;
+  paths: string[];
+  timestamp: string;
+  error?: string;
+}
+
+export interface HistoryContextsResponse {
+  available: boolean;
+  connected: boolean;
+  count: number;
+  contexts: string[];
+  timestamp: string;
+  error?: string;
+}

--- a/tests/signalk-client-history.e2e.spec.ts
+++ b/tests/signalk-client-history.e2e.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * SignalK Client History API Integration Tests
+ *
+ * Exercises getHistory/listHistoryPaths/listHistoryContexts against a live
+ * SignalK server. The History API needs a history provider plugin (for example
+ * signalk-to-influxdb); these tests probe for it in beforeAll and SKIP
+ * gracefully (still passing) when it is absent, so they do not fail on a vanilla
+ * server such as the Docker CI image (which runs with DISABLEPLUGINS=true).
+ *
+ * To run against a history-enabled server, point SIGNALK_HOST/PORT/TLS at it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { SignalKClient } from '../src/signalk-client.js';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('SignalK Client History API - Live Integration', () => {
+  let client: SignalKClient;
+  let historyEnabled = false;
+  let knownPaths: string[] = [];
+
+  const CONNECTION_TIMEOUT = 30000;
+
+  beforeAll(async () => {
+    client = new SignalKClient({
+      hostname: process.env.SIGNALK_HOST,
+      port: parseInt(process.env.SIGNALK_PORT || '3000'),
+      useTLS: process.env.SIGNALK_TLS === 'true',
+      context: process.env.SIGNALK_CONTEXT || 'vessels.self',
+    });
+
+    try {
+      await client.connect();
+    } catch (error) {
+      console.log(
+        `History tests skipped - could not reach a SignalK server: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    // Probe for a history provider. available:false means none is installed.
+    const contexts = await client.listHistoryContexts();
+    if (!contexts.available) {
+      console.log(
+        'History tests skipped - SignalK server has no history provider installed',
+      );
+      return;
+    }
+    historyEnabled = true;
+
+    const paths = await client.listHistoryPaths();
+    knownPaths = paths.paths || [];
+    console.log(
+      `History provider present; ${knownPaths.length} historized paths found`,
+    );
+  }, CONNECTION_TIMEOUT);
+
+  afterAll(() => {
+    if (client && client.connected) {
+      client.disconnect();
+    }
+  });
+
+  test('listHistoryPaths reports an available provider and an array of paths', () => {
+    if (!historyEnabled) {
+      return; // skipped - no provider on this server
+    }
+    expect(Array.isArray(knownPaths)).toBe(true);
+  });
+
+  test(
+    'getHistory returns a bounded per-path series for a recent window',
+    async () => {
+      if (!historyEnabled) {
+        return; // skipped - no provider on this server
+      }
+
+      const preferred = [
+        'navigation.speedOverGround',
+        'navigation.position',
+      ].filter((p) => knownPaths.includes(p));
+      const target = preferred[0] || knownPaths[0];
+      if (!target) {
+        console.log('No historized paths to query - skipping');
+        return;
+      }
+
+      const to = new Date();
+      const from = new Date(to.getTime() - 60 * 60 * 1000); // last hour
+
+      const h = await client.getHistory({
+        paths: target,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        resolution: 300,
+      });
+
+      expect(h.available).toBe(true);
+      expect(h.requestedPaths).toContain(target);
+      expect(Array.isArray(h.series)).toBe(true);
+      // Bounded result: ~12 buckets for one hour at 300s, never the full table.
+      expect(typeof h.rowCount).toBe('number');
+      expect(h.rowCount as number).toBeLessThan(1000);
+
+      if (h.series.length > 0) {
+        const points = h.values[h.series[0].path];
+        expect(Array.isArray(points)).toBe(true);
+        if (points.length > 0) {
+          expect(points[0]).toHaveProperty('timestamp');
+          expect(points[0]).toHaveProperty('value');
+        }
+      }
+    },
+    CONNECTION_TIMEOUT,
+  );
+});


### PR DESCRIPTION
**Branch:** `reliability-foundation` → targets `main` · **Stack position:** 1 of 12

## Stack & merge order

Part of a stack of read-only additions. Each branch builds on the one below it, and the
bottom of the stack builds on **#9 `feat/history-api`** (already open here, not yet merged).

GitHub only lets a PR target a branch that exists in this repository, and these parent
branches aren't on `main` yet — so **every PR in this stack targets `main`**, and its diff
currently includes the commits of everything beneath it. **Please review and merge them
bottom-up:** each PR's diff collapses to just its own changes once the PRs below it land.
(This PR is step 1; its diff is its own changes plus steps 1–0 and #9.)

| Step | PR | Branch |
|------|----|--------|
| prereq | #9 | `feat/history-api` — open here, **not yet merged** |
| 1 | #11 | `reliability-foundation` ⬅ **this PR** |
| 2 | #12 | `read-course-autopilot` |
| 3 | #13 | `read-weather` |
| 4 | #14 | `tools-mode-dispatch` |
| 5 | #15 | `standardize-example-coordinates` |
| 6 | #16 | `server-feature-discovery` |
| 7 | #17 | `anchor-watch-docs` |
| 8 | #18 | `alarm-enrichment` |
| 9 | #19 | `resources-reads` |
| 10 | #20 | `radar-targets` |
| 11 | #21 | `unified-targets` |
| 12 | #22 | `units-metadata-docs` |

---
## Summary

Groundwork that the later read changes build on. Adds a single place that
every HTTP read goes through, so a flaky boat network can no longer hang a
request forever, and adds a test that locks the tool-name ↔ binding-method
naming contract before new tools start relying on it.

## What changed

- **`fetchJson(url, init?, opts?)`** on `SignalKClient`: wraps `fetch` with an
  `AbortController` timeout (default 10s) and one bounded retry. The retry only
  fires on a timeout (`AbortError`); a hard network or parse error fails fast.
  Auth headers come from `buildFetchOptions()` as before. All existing GET sites
  were refactored onto it, so the timeout/retry behaviour is uniform.
- Unified the auth-failure message to `... set SIGNALK_TOKEN ...` across reads.
- **Parity guardrail test**: asserts every tool from `getToolDefinitions()`
  maps (via `toCamelCase`) to a real method on `SignalKBinding`. The only
  exceptions are `execute_code` and `get_initial_context`. This catches a
  renamed tool or a missing binding method at test time instead of at runtime.
- Adds `docs/signalk-api-specs/` to `.gitignore` — those are downloaded local
  reference specs, not part of the package.

## Testing

- New unit test drives the timeout path with a never-resolving fetch mock and
  asserts graceful degradation (`available:false`), plus the retry-only-on-
  timeout behaviour.
- New parity test over the full tool list.
- `npm run typecheck`, `npm run test:unit`, `npm run lint` all clean.

## Notes

- No behaviour change for callers beyond bounded timeouts; reads still degrade
  gracefully and never throw.
- Later branches build on this one — `read-course-autopilot`, `read-weather`,
  `tools-mode-dispatch`, and `standardize-example-coordinates`.

## Commits

```
Keep downloaded SignalK API specs out of git
Add a failing test for request timeouts (red)
Add a request timeout and retry to the SignalK client (green)
Add a tool/binding parity guardrail test
```
