### PR TITLE
Add read-only course and autopilot status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ docker/signalk-config/*
 # Test results
 test-results/
 
+# Local-only reference: SignalK API specs downloaded from a live server.
+# Kept out of git so no server host / vessel data is ever committed.
+docs/signalk-api-specs/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the SignalK MCP Server project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **SignalK History API support.** Three new SDK functions are available inside `execute_code`:
+  - `getHistory({ paths, from, to, duration, resolution, aggregate, context })` - query aggregated historical time-series for one or more paths.
+  - `listHistoryPaths(options?)` - list paths that have history in a time window.
+  - `listHistoryContexts(options?)` - list vessels that have history.
+- Queries the SignalK v2 History API (`/signalk/v2/api/history/...`) and reshapes the tabular response into easy per-path lists of `{ timestamp, value }` points, so agent code can summarize thousands of rows down to a few numbers inside the isolate.
+- Notes for callers: times are ISO-8601 and `resolution` is in **seconds**; aggregation can be set inline per path (e.g. `navigation.speedOverGround:max`); `navigation.position` history values are `[longitude, latitude]` arrays (unlike the live API's `{latitude, longitude}`); and `null` marks a data gap.
+- Requires a SignalK server with a history provider (e.g. `signalk-to-influxdb`). When none is installed, the functions return `available: false` instead of failing, so code-execution mode keeps working.
+
 ## [1.0.8] - 2025-11-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ const heading = await getPathValue({ path: "navigation.headingTrue" });
 
 // Connection status - ALSO requires await!
 const status = await getConnectionStatus();
+
+// Recorded history over a time range (see "Historical Data" below)
+const past = await getHistory({ paths: 'navigation.speedOverGround', from: '2026-06-11T06:00:00Z', resolution: 300 });
+const historyPaths = await listHistoryPaths();    // which paths have history
 ```
 
 ### Real-time Marine Data
@@ -229,6 +233,136 @@ SERVER_VERSION=1.0.6
 ```
 
 **Result:** ~300 tokens (vs 13,000 with 3 separate tool calls!)
+
+## Historical Data (History API)
+
+The SDK functions above return **live** values. The History API lets the AI look at **recorded** data over time - your track from this morning, how the wind built over the afternoon, how much the batteries drained overnight. As with everything else, the code runs in the isolate, so the AI can boil thousands of recorded points down to a few numbers before any of it reaches the model.
+
+### Requirements
+
+History is recorded by a separate SignalK plugin, so the requirements are on your **SignalK server** (not on this MCP server):
+
+- **SignalK Server 2.15 or newer** (this is where the v2 History API lives).
+- **A history provider plugin that is installed and recording**, most commonly [`signalk-to-influxdb`](https://www.npmjs.com/package/@signalk/signalk-to-influxdb) writing to an InfluxDB database. (`signalk-to-timescaledb` works too.)
+
+If no provider is installed, the history functions still return safely with `available: false` - they never break code execution mode.
+
+### Setup (on the SignalK server)
+
+1. In the SignalK admin web page, open **Appstore → Available** and install **signalk-to-influxdb** (plus an InfluxDB database for it to write to - many boat setups already run one).
+2. Turn the plugin on and let it record for a while so there is some history to query.
+3. Point this MCP server at that SignalK server the usual way (`SIGNALK_HOST` / `SIGNALK_PORT` / `SIGNALK_TLS`). If your server needs a login to read history, set `SIGNALK_TOKEN`.
+
+To check at any time whether history is turned on:
+
+```javascript
+(async () => {
+  const probe = await listHistoryContexts();
+  return JSON.stringify({ historyAvailable: probe.available });
+})()
+```
+
+### History SDK functions
+
+```javascript
+// Query recorded values for one or more paths over a time range
+const h = await getHistory({
+  paths: 'navigation.speedOverGround',  // a path, or an array of paths
+  from: '2026-06-11T06:00:00Z',         // ISO-8601; give "from" or "duration"
+  to:   '2026-06-11T12:00:00Z',         // ISO-8601 (optional, defaults to now)
+  resolution: 300                        // bucket size in SECONDS (300 = 5 min)
+});
+
+// Discover what is recorded
+const paths    = await listHistoryPaths();     // which paths have history
+const contexts = await listHistoryContexts();  // which vessels have history
+```
+
+**Good to know:**
+
+- **Times are ISO-8601** (like `2026-06-11T06:00:00Z`) and **`resolution` is in seconds**, not milliseconds.
+- Pick an **aggregation method per path** by adding it to the path: `'navigation.speedOverGround:max'` or `'environment.wind.speedApparent:sma:5'`. The default is `average` (and `first` for position).
+- `getHistory` returns `{ available, values, series, rowCount }`. `values` is grouped by path, so `values['navigation.speedOverGround']` is a list of `{ timestamp, value }`.
+- **Positions are `[longitude, latitude]` arrays** in history (the live API uses `{ latitude, longitude }`). `null` means there was no data in that bucket - drop nulls before averaging.
+- Always check **`available`** first. `available: false` means no history provider is installed on the server.
+
+### Sample use cases
+
+| Ask | What the code does in the isolate |
+|-----|-----------------------------------|
+| "How far did we sail today, and our average speed while moving?" | Adds up speed over time for distance; ignores time at the dock |
+| "How did the wind build this afternoon?" | Averages wind into short steps and reports the trend and biggest gust |
+| "Show this morning's track" | Pulls position history and thins it down to a handful of waypoints |
+| "How much did the batteries drain overnight?" | Totals battery current over the night into a simple energy summary |
+| "When will we need to refuel?" | Fits a line through tank-level history to estimate burn rate and days left |
+| "Any engine temperature spikes today?" | Scans engine-temp history for spikes and time at high RPM |
+| "What was the roughest weather in the last two days?" | Finds the peak wind and the barometer trend |
+| "The low-battery alarm just fired - what led up to it?" | Pulls the 30 minutes before the alarm and finds where the voltage dropped |
+
+### Example 5: Distance sailed today
+
+**Query:** "How far have we sailed today, and what's our average speed while moving?"
+
+**Code:**
+```javascript
+(async () => {
+  const h = await getHistory({
+    paths: 'navigation.speedOverGround',
+    from: '2026-06-11T00:00:00Z',
+    to:   '2026-06-11T23:59:59Z',
+    resolution: 60                       // 1-minute buckets
+  });
+  if (!h.available) return JSON.stringify({ note: h.error });
+
+  const points = h.values['navigation.speedOverGround'].filter(p => p.value != null);
+
+  let meters = 0, movingMinutes = 0;
+  for (const p of points) {
+    meters += p.value * 60;              // speed (m/s) over a 60s bucket
+    if (p.value > 0.26) movingMinutes++; // moving if faster than ~0.5 knots
+  }
+  const movingHours = movingMinutes / 60;
+
+  return JSON.stringify({
+    distanceNm: (meters / 1852).toFixed(1),
+    movingHours: movingHours.toFixed(1),
+    avgKnotsWhileMoving: movingHours
+      ? ((meters / (movingHours * 3600)) * 1.94384).toFixed(1)
+      : '0'
+  });
+})()
+```
+
+**Result:** A 3-number summary instead of ~1,400 raw speed readings.
+
+### Example 6: This morning's track
+
+**Query:** "Show me the route we took this morning."
+
+**Code:**
+```javascript
+(async () => {
+  const h = await getHistory({
+    paths: 'navigation.position',        // recorded as [longitude, latitude]
+    from: '2026-06-11T06:00:00Z',
+    to:   '2026-06-11T12:00:00Z',
+    resolution: 120                      // a fix every 2 minutes
+  });
+  if (!h.available) return JSON.stringify({ note: h.error });
+
+  const track = h.values['navigation.position']
+    .filter(p => p.value != null)
+    .map(p => ({ lon: p.value[0], lat: p.value[1], time: p.timestamp })); // [lon, lat]!
+
+  return JSON.stringify({
+    fixes: track.length,
+    start: track[0],
+    end: track[track.length - 1]
+  });
+})()
+```
+
+**Result:** A short list of waypoints instead of thousands of position fixes.
 
 ## Development
 

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -65,6 +65,33 @@
         "note": "This function is also async - MUST use await",
         "returns": "Object with connected, url, hostname, port, context, timestamp",
         "example": "const status = await getConnectionStatus();\nconsole.log('Connected:', status.connected);"
+      },
+      "getHistory": {
+        "signature": "await getHistory({ paths, from, to, duration, resolution, aggregate, context })",
+        "description": "Query aggregated historical time-series for one or more SignalK paths. Requires a SignalK history provider (e.g. signalk-to-influxdb).",
+        "parameters": {
+          "paths": "Path string or array of paths; add an inline aggregation method as path:method[:param], e.g. 'navigation.speedOverGround:sma:5'",
+          "from": "ISO-8601 start time; provide 'from' or 'duration'",
+          "to": "ISO-8601 end time (defaults to now)",
+          "duration": "ISO-8601 duration (PT1H) or seconds; use instead of 'from'",
+          "resolution": "Bucket size in SECONDS (not milliseconds), e.g. 60 for 1-minute buckets",
+          "aggregate": "Default method for bare paths: average|min|max|first|last (default average)",
+          "context": "Vessel context (default vessels.self)"
+        },
+        "returns": "{ available, values: { '<path>': [{ timestamp, value }] }, series, missingPaths, rowCount }. Check 'available' (false = no history provider). null marks a data gap. navigation.position values are [longitude, latitude] ARRAYS, unlike live getVesselState which uses {latitude, longitude}.",
+        "example": "(async () => {\n  const h = await getHistory({ paths: 'navigation.speedOverGround:max', from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300 });\n  if (!h.available) return JSON.stringify({ note: h.error });\n  const pts = h.values['navigation.speedOverGround'].filter(p => p.value != null);\n  return JSON.stringify({ maxKn: (Math.max(...pts.map(p => p.value)) * 1.94384).toFixed(1) });\n})()"
+      },
+      "listHistoryPaths": {
+        "signature": "await listHistoryPaths(options?)",
+        "description": "List SignalK paths that have historical data in a time window. Defaults to the last 24 hours.",
+        "returns": "{ available, count, paths: string[] }. available:false means no history provider.",
+        "example": "const h = await listHistoryPaths();\nif (h.available) console.log(h.paths.length, 'historized paths');"
+      },
+      "listHistoryContexts": {
+        "signature": "await listHistoryContexts(options?)",
+        "description": "List vessel contexts that have historical data. Call before get_history to discover which vessels have history.",
+        "returns": "{ available, count, contexts: string[] }",
+        "example": "const h = await listHistoryContexts();\nif (h.available) console.log(h.contexts);"
       }
     }
   },
@@ -116,7 +143,11 @@
     "units": "All SignalK values use SI units (meters, seconds, Kelvin, radians)",
     "timestamps": "All data includes RFC 3339 timestamps for freshness checking",
     "missing_data": "Paths may not exist if sensors/systems not installed",
-    "null_values": "Null values indicate sensor offline or no valid reading"
+    "null_values": "Null values indicate sensor offline or no valid reading",
+    "history_times": "History query times are ISO-8601 only; resolution is in SECONDS (not milliseconds)",
+    "history_positions": "In history results, navigation.position is a [longitude, latitude] array - NOT the {latitude, longitude} object that live getVesselState/getPathValue return",
+    "history_gaps": "In history results, null marks a time bucket with no data - filter nulls before averaging or integrating",
+    "history_availability": "get_history/list_history_* return available:false when the SignalK server has no history provider installed"
   },
   "legacy_tools": {
     "status": "DEPRECATED - Available only in 'tools' or 'hybrid' mode",

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -98,6 +98,12 @@
         "description": "Current navigation course: active route/destination plus calculated values (cross-track error, bearing, ETA, VMG, time-to-go). Values are SI (distance in metres, bearings in radians).",
         "returns": "{ available, navigating, course, calcValues }. navigating is false (and calcValues null) when no destination is set. available:false means the course API is unavailable.",
         "example": "(async () => {\n  const c = await getCourseStatus();\n  if (!c.available) return JSON.stringify({ note: c.error });\n  if (!c.navigating) return JSON.stringify({ navigating: false });\n  return JSON.stringify({ distanceNm: (c.calcValues.distance / 1852).toFixed(2), bearingDeg: (c.calcValues.bearingTrue * 57.2958).toFixed(0) });\n})()"
+      },
+      "getAutopilotStatus": {
+        "signature": "await getAutopilotStatus(pilotId?)",
+        "description": "Read-only autopilot status: engaged/state/mode/target plus the available states, modes and actions. With no pilotId it picks the default device. Target is reported in both radians and degrees.",
+        "returns": "{ available, pilotId, pilotIds, engaged, state, mode, targetDegrees, targetRadians, options }. pilotIds lists every autopilot device. targetDegrees/targetRadians are null when no target is set (e.g. standby). available:false means the autopilot API is unavailable.",
+        "example": "(async () => {\n  const ap = await getAutopilotStatus();\n  if (!ap.available) return JSON.stringify({ note: ap.error });\n  return JSON.stringify({ pilot: ap.pilotId, engaged: ap.engaged, state: ap.state, mode: ap.mode, headingDeg: ap.targetDegrees == null ? null : ap.targetDegrees.toFixed(0) });\n})()"
       }
     }
   },

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -92,6 +92,12 @@
         "description": "List vessel contexts that have historical data. Call before get_history to discover which vessels have history.",
         "returns": "{ available, count, contexts: string[] }",
         "example": "const h = await listHistoryContexts();\nif (h.available) console.log(h.contexts);"
+      },
+      "getCourseStatus": {
+        "signature": "await getCourseStatus()",
+        "description": "Current navigation course: active route/destination plus calculated values (cross-track error, bearing, ETA, VMG, time-to-go). Values are SI (distance in metres, bearings in radians).",
+        "returns": "{ available, navigating, course, calcValues }. navigating is false (and calcValues null) when no destination is set. available:false means the course API is unavailable.",
+        "example": "(async () => {\n  const c = await getCourseStatus();\n  if (!c.available) return JSON.stringify({ note: c.error });\n  if (!c.navigating) return JSON.stringify({ navigating: false });\n  return JSON.stringify({ distanceNm: (c.calcValues.distance / 1852).toFixed(2), bearingDeg: (c.calcValues.bearingTrue * 57.2958).toFixed(0) });\n})()"
       }
     }
   },

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -10,6 +10,7 @@ import type {
   HistoryResponse,
   HistoryPathsResponse,
   HistoryContextsResponse,
+  CourseStatusResponse,
 } from '../types/index.js';
 
 /**
@@ -224,6 +225,21 @@ export class SignalKBinding {
     duration?: string | number;
   }): Promise<HistoryContextsResponse> {
     return this.client.listHistoryContexts(options);
+  }
+
+  /**
+   * Current navigation course - active route / destination plus calculated
+   * values (cross-track error, bearing, ETA, VMG, time-to-go).
+   *
+   * @returns CourseStatusResponse; available:false if the course API is
+   *   unavailable, navigating:false when no destination is set.
+   *
+   * @example
+   * const c = await signalk.getCourseStatus();
+   * if (c.navigating) console.log('XTE:', c.calcValues?.crossTrackError);
+   */
+  async getCourseStatus(): Promise<CourseStatusResponse> {
+    return this.client.getCourseStatus();
   }
 
   /**

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -11,6 +11,7 @@ import type {
   HistoryPathsResponse,
   HistoryContextsResponse,
   CourseStatusResponse,
+  AutopilotStatusResponse,
 } from '../types/index.js';
 
 /**
@@ -240,6 +241,22 @@ export class SignalKBinding {
    */
   async getCourseStatus(): Promise<CourseStatusResponse> {
     return this.client.getCourseStatus();
+  }
+
+  /**
+   * Autopilot status (read-only) - engaged / state / mode / target plus the
+   * available states, modes and actions.
+   *
+   * @param pilotId - optional device id; defaults to the vessel's default pilot
+   * @returns AutopilotStatusResponse; available:false if the autopilot API is
+   *   unavailable.
+   *
+   * @example
+   * const ap = await signalk.getAutopilotStatus();
+   * console.log(ap.engaged, ap.state, ap.targetDegrees);
+   */
+  async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
+    return this.client.getAutopilotStatus(pilotId);
   }
 
   /**

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -6,6 +6,10 @@ import type {
   AvailablePathsResponse,
   PathValueResponse,
   ConnectionStatus,
+  HistoryQueryOptions,
+  HistoryResponse,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from '../types/index.js';
 
 /**
@@ -173,6 +177,53 @@ export class SignalKBinding {
   async getPathValue(pathOrOptions: string | { path: string }): Promise<PathValueResponse> {
     const path = typeof pathOrOptions === 'string' ? pathOrOptions : pathOrOptions.path;
     return this.client.getPathValue(path);
+  }
+
+  /**
+   * Query historical time-series for one or more SignalK paths.
+   *
+   * Requires a SignalK server with a history provider (e.g. signalk-to-influxdb).
+   * Returns per-path arrays of { timestamp, value }. All times are ISO-8601 and
+   * `resolution` is in SECONDS. navigation.position values are [lon, lat] arrays.
+   * Check `available` - it is false when no history provider is installed.
+   *
+   * @example
+   * // In agent code
+   * const h = await signalk.getHistory({
+   *   paths: 'navigation.speedOverGround:max',
+   *   from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300
+   * });
+   * if (h.available) {
+   *   const sog = h.values['navigation.speedOverGround'].filter(p => p.value != null);
+   * }
+   */
+  async getHistory(options: HistoryQueryOptions): Promise<HistoryResponse> {
+    return this.client.getHistory(options);
+  }
+
+  /**
+   * List SignalK paths that have historical data in a time window.
+   * @returns HistoryPathsResponse; available:false means no history provider
+   */
+  async listHistoryPaths(options?: {
+    from?: string;
+    to?: string;
+    duration?: string | number;
+    context?: string;
+  }): Promise<HistoryPathsResponse> {
+    return this.client.listHistoryPaths(options);
+  }
+
+  /**
+   * List vessel contexts that have historical data in a time window.
+   * @returns HistoryContextsResponse; available:false means no history provider
+   */
+  async listHistoryContexts(options?: {
+    from?: string;
+    to?: string;
+    duration?: string | number;
+  }): Promise<HistoryContextsResponse> {
+    return this.client.listHistoryContexts(options);
   }
 
   /**

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -2081,6 +2081,115 @@ describe('SignalKClient', () => {
     });
   });
 
+  describe('getAutopilotStatus', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    const ok = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const err = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve(''),
+      } as Response);
+
+    const deviceOffline = {
+      options: { states: [], modes: [], actions: [] },
+      state: 'standby',
+      mode: null,
+      target: null,
+      engaged: false,
+    };
+    const deviceEngaged = {
+      options: { states: [], modes: [], actions: [] },
+      state: 'auto',
+      mode: 'compass',
+      target: Math.PI / 2,
+      engaged: true,
+    };
+
+    test('no autopilot devices => available:true, empty', async () => {
+      mockFetch.mockResolvedValueOnce(ok({}));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(true);
+      expect(r.pilotIds).toEqual([]);
+      expect(r.pilotId).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('default device picked via isDefault; offline target stays null', async () => {
+      mockFetch.mockResolvedValueOnce(
+        ok({ 'pilot-a': { isDefault: false }, 'pilot-b': { isDefault: true } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok(deviceOffline));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(true);
+      expect(r.pilotId).toBe('pilot-b');
+      expect(r.pilotIds).toEqual(['pilot-a', 'pilot-b']);
+      expect(r.engaged).toBe(false);
+      expect(r.state).toBe('standby');
+      expect(r.targetRadians).toBeNull();
+      expect(r.targetDegrees).toBeNull();
+      expect(mockFetch.mock.calls[1][0] as string).toContain(
+        '/autopilots/pilot-b',
+      );
+    });
+
+    test('target radians converted to degrees when engaged', async () => {
+      mockFetch.mockResolvedValueOnce(ok({ 'pilot-b': { isDefault: true } }));
+      mockFetch.mockResolvedValueOnce(ok(deviceEngaged));
+      const r = await client.getAutopilotStatus();
+      expect(r.engaged).toBe(true);
+      expect(r.targetRadians).toBeCloseTo(Math.PI / 2);
+      expect(r.targetDegrees).toBeCloseTo(90);
+    });
+
+    test('no isDefault => resolve via _providers/_default', async () => {
+      mockFetch.mockResolvedValueOnce(
+        ok({ 'pilot-a': { isDefault: false }, 'pilot-b': { isDefault: false } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok({ id: 'pilot-b' }));
+      mockFetch.mockResolvedValueOnce(ok(deviceOffline));
+      const r = await client.getAutopilotStatus();
+      expect(r.pilotId).toBe('pilot-b');
+      expect(mockFetch.mock.calls[1][0] as string).toContain(
+        '/_providers/_default',
+      );
+    });
+
+    test('explicit pilotId reads that device', async () => {
+      mockFetch.mockResolvedValueOnce(
+        ok({ 'pilot-a': { isDefault: true }, 'pilot-b': { isDefault: false } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok(deviceOffline));
+      const r = await client.getAutopilotStatus('pilot-b');
+      expect(r.pilotId).toBe('pilot-b');
+      expect(mockFetch.mock.calls[1][0] as string).toContain(
+        '/autopilots/pilot-b',
+      );
+    });
+
+    test('autopilot API unavailable (404) => available:false', async () => {
+      mockFetch.mockResolvedValueOnce(err(404));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(false);
+      expect(r.pilotIds).toEqual([]);
+    });
+
+    test('network error => available:false, no throw', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(false);
+    });
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1949,6 +1949,43 @@ describe('SignalKClient', () => {
     });
   });
 
+  describe('Request reliability (timeout + retry)', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    test('a hung server times out gracefully instead of stalling the call', async () => {
+      jest.useFakeTimers();
+      try {
+        // The server "hangs": fetch only settles if its request is aborted.
+        mockFetch.mockImplementation(
+          (_url: any, init: any) =>
+            new Promise((_resolve, reject) => {
+              const signal = (init && init.signal) as AbortSignal | undefined;
+              signal?.addEventListener('abort', () =>
+                reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+              );
+            }) as any,
+        );
+
+        const pending = client.listAvailablePaths();
+        // Drive the initial timeout and the one retry.
+        await jest.advanceTimersByTimeAsync(60000);
+        const res = await pending;
+
+        expect(res.connected).toBe(false);
+        expect(typeof res.error).toBe('string');
+        expect(res.error).toMatch(/tim(e|ed)\s?out|failed/i);
+      } finally {
+        jest.useRealTimers();
+      }
+    }, 15000);
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1948,4 +1948,268 @@ describe('SignalKClient', () => {
       expect((client as any).shouldIncludeAISPath('unknown.path')).toBe(false);
     });
   });
+
+  describe('History Methods', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    // A small real-shaped fixture: two columns (a scalar + a position) and a
+    // null gap in the last row.
+    const valuesFixture = {
+      context: 'vessels.self',
+      range: { from: '2026-06-11T06:00:00.000Z', to: '2026-06-11T06:10:00.000Z' },
+      values: [
+        { path: 'navigation.speedOverGround', method: 'max' },
+        { path: 'navigation.position', method: 'first' },
+      ],
+      data: [
+        ['2026-06-11T06:00:00.000Z', 3.14, [-122.47, 37.81]],
+        ['2026-06-11T06:05:00.000Z', 0, [-122.48, 37.82]],
+        ['2026-06-11T06:10:00.000Z', null, null],
+      ],
+    };
+
+    const okJson = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const errResp = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve('boom'),
+      } as Response);
+
+    describe('buildHistoryApiUrl', () => {
+      test('targets the v2 history base and drops undefined params', () => {
+        const url = client.buildHistoryApiUrl('values', {
+          context: 'vessels.self',
+          paths: 'navigation.speedOverGround:max',
+          from: '2026-06-11T06:00:00Z',
+          to: undefined,
+          resolution: 60,
+        });
+        expect(
+          url.startsWith('http://example.com:3000/signalk/v2/api/history/values?'),
+        ).toBe(true);
+        const decoded = decodeURIComponent(url);
+        expect(decoded).toContain('paths=navigation.speedOverGround:max');
+        expect(decoded).toContain('from=2026-06-11T06:00:00Z');
+        expect(decoded).toContain('resolution=60'); // seconds, not ms
+        expect(url).not.toContain('to='); // undefined dropped
+      });
+    });
+
+    describe('getHistory transform', () => {
+      test('maps each response column to its path by index, keeping nulls and [lon,lat]', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        const h = await client.getHistory({
+          paths: ['navigation.speedOverGround:max', 'navigation.position:first'],
+          from: '2026-06-11T06:00:00Z',
+          to: '2026-06-11T06:10:00Z',
+          resolution: 300,
+        });
+        expect(h.available).toBe(true);
+        expect(h.rowCount).toBe(3);
+        const sog = h.values['navigation.speedOverGround'];
+        expect(sog.map((p) => p.value)).toEqual([3.14, 0, null]); // 0 kept, null strict
+        const pos = h.values['navigation.position'];
+        expect(pos[0].value).toEqual([-122.47, 37.81]); // array passthrough
+        expect(pos[2].value).toBeNull();
+        expect(h.series).toHaveLength(2);
+        expect(h.series[1].method).toBe('first');
+        expect(h.missingPaths).toEqual([]);
+      });
+
+      test('keys by RESPONSE order, not request order', async () => {
+        const shuffled = {
+          ...valuesFixture,
+          values: [
+            { path: 'navigation.position', method: 'first' },
+            { path: 'navigation.speedOverGround', method: 'max' },
+          ],
+          data: [['2026-06-11T06:00:00.000Z', [-1, 2], 9.9]],
+        };
+        mockFetch.mockResolvedValueOnce(okJson(shuffled));
+        const h = await client.getHistory({
+          paths: ['navigation.speedOverGround', 'navigation.position'],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.values['navigation.position'][0].value).toEqual([-1, 2]);
+        expect(h.values['navigation.speedOverGround'][0].value).toBe(9.9);
+      });
+
+      test('keeps duplicate paths in series and reports missing paths', async () => {
+        const dup = {
+          context: 'vessels.self',
+          range: { from: 'a', to: 'b' },
+          values: [
+            { path: 'navigation.speedOverGround', method: 'max' },
+            { path: 'navigation.speedOverGround', method: 'min' },
+          ],
+          data: [['t', 5, 1]],
+        };
+        mockFetch.mockResolvedValueOnce(okJson(dup));
+        const h = await client.getHistory({
+          paths: [
+            'navigation.speedOverGround:max',
+            'navigation.speedOverGround:min',
+            'tanks.fuel.level',
+          ],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.series).toHaveLength(2);
+        expect(h.series[0].method).toBe('max');
+        expect(h.series[1].method).toBe('min');
+        // values map keyed by bare path - last (min) wins
+        expect(h.values['navigation.speedOverGround'][0].value).toBe(1);
+        expect(h.missingPaths).toContain('tanks.fuel.level');
+      });
+
+      test('empty data window is available:true with rowCount 0 (not unavailable)', async () => {
+        mockFetch.mockResolvedValueOnce(
+          okJson({
+            context: 'vessels.self',
+            range: { from: 'a', to: 'b' },
+            values: [{ path: 'navigation.speedOverGround', method: 'average' }],
+            data: [],
+          }),
+        );
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.rowCount).toBe(0);
+        expect(h.values['navigation.speedOverGround']).toEqual([]);
+      });
+    });
+
+    describe('paths composition', () => {
+      test('applies default aggregate to bare paths but not to inline or position', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: [
+            'navigation.speedOverGround',
+            'environment.wind.speedApparent:sma:5',
+            'navigation.position',
+          ],
+          aggregate: 'max',
+          from: '2026-06-11T06:00:00Z',
+        });
+        const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        expect(url).toContain(
+          'paths=navigation.speedOverGround:max,environment.wind.speedApparent:sma:5,navigation.position',
+        );
+      });
+
+      test('string and array paths produce the same request', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: 'navigation.speedOverGround:max',
+          from: '2026-06-11T06:00:00Z',
+        });
+        const a = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: ['navigation.speedOverGround:max'],
+          from: '2026-06-11T06:00:00Z',
+        });
+        const b = decodeURIComponent(mockFetch.mock.calls[1][0] as string);
+        expect(a).toBe(b);
+      });
+    });
+
+    describe('input guards (no request sent)', () => {
+      test('missing from and duration => available:true with a clear error, no fetch', async () => {
+        const h = await client.getHistory({ paths: 'navigation.speedOverGround' });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/from.*duration/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+      test('non-ISO from => distinct error, no fetch', async () => {
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: 'yesterday',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/ISO-8601/);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+      test('no paths => clear error, no fetch', async () => {
+        const h = await client.getHistory({
+          paths: [],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/path/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('graceful degradation (never throws, no cache fallback)', () => {
+      test('404 => available:false (no provider)', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(404));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(false);
+        expect(h.values).toEqual({});
+        expect(h.error).toMatch(/not available|provider/i);
+      });
+      test('400 => available:true with invalid-query error', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(400));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/invalid/i);
+      });
+      test('401 => available:true asking for auth', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(401));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/auth|SIGNALK_TOKEN/i);
+      });
+      test('network error => available:false, no throw', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('network down'));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(false);
+        expect(h.values).toEqual({});
+      });
+    });
+
+    describe('listHistoryPaths / listHistoryContexts', () => {
+      test('parse a JSON array of strings and default to a 24h window', async () => {
+        mockFetch.mockResolvedValueOnce(
+          okJson(['navigation.position', 'electrical.batteries.house.voltage']),
+        );
+        const r = await client.listHistoryPaths();
+        expect(r.available).toBe(true);
+        expect(r.count).toBe(2);
+        expect(r.paths).toContain('navigation.position');
+        const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        expect(url).toContain('/signalk/v2/api/history/paths');
+        expect(url).toContain('duration=PT24H');
+      });
+      test('contexts 404 => available:false', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(404));
+        const r = await client.listHistoryContexts();
+        expect(r.available).toBe(false);
+        expect(r.contexts).toEqual([]);
+      });
+    });
+  });
 });

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -871,7 +871,8 @@ describe('SignalKClient', () => {
       expect(client.connected).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/signalk/v1/api/vessels/self'),
-        {}, // buildFetchOptions() returns empty object when no token
+        // fetchJson now attaches an AbortController signal for the timeout.
+        expect.objectContaining({ signal: expect.anything() }),
       );
     });
 

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1987,6 +1987,100 @@ describe('SignalKClient', () => {
     }, 15000);
   });
 
+  describe('getCourseStatus', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    const ok = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const err = (status: number, body: any) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      } as Response);
+
+    // Scrubbed fixtures (shape captured from a live server, no real data).
+    const notNavigating = {
+      startTime: null,
+      targetArrivalTime: null,
+      arrivalCircle: 0,
+      activeRoute: null,
+      nextPoint: null,
+      previousPoint: null,
+    };
+    const navigating = {
+      startTime: '2026-01-01T00:00:00.000Z',
+      targetArrivalTime: null,
+      arrivalCircle: 100,
+      activeRoute: null,
+      nextPoint: { type: 'Location', position: { latitude: 1, longitude: 2 } },
+      previousPoint: { type: 'Location', position: { latitude: 0, longitude: 0 } },
+    };
+    const calc = {
+      distance: 1234,
+      bearingTrue: 1.2,
+      velocityMadeGood: 2.3,
+      timeToGo: 3600,
+      estimatedTimeOfArrival: '2026-01-01T01:00:00.000Z',
+      crossTrackError: 12,
+    };
+
+    test('not navigating: navigating:false, calcValues:null, no calcValues request', async () => {
+      mockFetch.mockResolvedValueOnce(ok(notNavigating));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(true);
+      expect(r.navigating).toBe(false);
+      expect(r.course).toEqual(notNavigating);
+      expect(r.calcValues).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('navigating: merges /course and /course/calcValues', async () => {
+      mockFetch.mockResolvedValueOnce(ok(navigating));
+      mockFetch.mockResolvedValueOnce(ok(calc));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(true);
+      expect(r.navigating).toBe(true);
+      expect(r.calcValues).toEqual(calc);
+      expect(decodeURIComponent(mockFetch.mock.calls[1][0] as string)).toContain(
+        '/navigation/course/calcValues',
+      );
+    });
+
+    test('a 400 from calcValues while navigating leaves calcValues null, not an error', async () => {
+      mockFetch.mockResolvedValueOnce(ok(navigating));
+      mockFetch.mockResolvedValueOnce(
+        err(400, { statusCode: 400, message: 'No active destination!' }),
+      );
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(true);
+      expect(r.navigating).toBe(true);
+      expect(r.calcValues).toBeNull();
+      expect(r.error).toBeUndefined();
+    });
+
+    test('course API unavailable (404) => available:false, never throws', async () => {
+      mockFetch.mockResolvedValueOnce(err(404, {}));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(false);
+      expect(r.course).toBeNull();
+    });
+
+    test('network error => available:false, no throw', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(false);
+    });
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -143,6 +143,34 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * Build a SignalK v2 History API URL.
+   *
+   * The History API lives at /signalk/v2/api/history/<endpoint> - a different
+   * base path from buildRestApiUrl (/signalk/v1/api/vessels/...). Query values
+   * that are undefined or empty are dropped. Reserved characters in the path
+   * expression (':' and ',') are percent-encoded by URLSearchParams and decoded
+   * by the server before it splits them.
+   *
+   * @param endpoint - 'values', 'contexts', or 'paths'
+   * @param params - query parameters; undefined/empty values are omitted
+   * @returns Complete History API URL
+   */
+  buildHistoryApiUrl(
+    endpoint: 'values' | 'contexts' | 'paths',
+    params: Record<string, string | number | undefined> = {},
+  ): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        query.set(key, String(value));
+      }
+    }
+    const queryString = query.toString();
+    const suffix = queryString ? `?${queryString}` : '';
+    return `${this.buildHttpUrl()}/signalk/v2/api/history/${endpoint}${suffix}`;
+  }
+
+  /**
    * Build fetch options with authentication headers if token is configured
    * @returns RequestInit object with authorization header if token exists
    */

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -191,6 +191,49 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * fetch() wrapped with an AbortController timeout and one bounded retry, so a
+   * hung or flaky SignalK server fails fast and legibly instead of stalling a
+   * tool call. Auth headers (buildFetchOptions) are applied automatically.
+   * Returns the Response; callers handle response.ok / .json() as before.
+   */
+  private async fetchJson(
+    url: string,
+    init: RequestInit = {},
+    opts: { timeoutMs?: number; retries?: number } = {},
+  ): Promise<Response> {
+    const timeoutMs = opts.timeoutMs ?? 10000;
+    const retries = opts.retries ?? 1;
+    const base = this.buildFetchOptions();
+
+    let lastError: any;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        return await fetch(url, {
+          ...base,
+          ...init,
+          headers: { ...(base.headers as any), ...(init.headers as any) },
+          signal: controller.signal,
+        });
+      } catch (error: any) {
+        const aborted = error?.name === 'AbortError';
+        lastError = aborted
+          ? new Error(`Request timed out after ${timeoutMs}ms`)
+          : error;
+        // Retry once on a timeout only; a hard network/parse error fails fast.
+        if (!aborted || attempt >= retries) {
+          throw lastError;
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    // Unreachable (the loop either returns or throws), satisfies the type checker.
+    throw lastError;
+  }
+
+  /**
    * Sets up WebSocket event handlers for connection, disconnection, errors, and delta messages
    *
    * Event handlers:
@@ -254,7 +297,7 @@ export class SignalKClient extends EventEmitter {
     // Test HTTP connectivity
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -320,7 +363,7 @@ export class SignalKClient extends EventEmitter {
   private async fetchInitialVesselState(): Promise<void> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -626,7 +669,7 @@ export class SignalKClient extends EventEmitter {
   async getVesselState(): Promise<VesselState> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -839,7 +882,7 @@ export class SignalKClient extends EventEmitter {
 
       // Fetch all vessels from the API
       const apiUrl = `${this.buildHttpUrl()}/signalk/v1/api/vessels`;
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1034,7 +1077,7 @@ export class SignalKClient extends EventEmitter {
   async getActiveAlarms(): Promise<ActiveAlarmsResponse> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1133,7 +1176,7 @@ export class SignalKClient extends EventEmitter {
       // Use helper method to build REST API URL
       const apiUrl = this.buildRestApiUrl('self');
 
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -1236,7 +1279,7 @@ export class SignalKClient extends EventEmitter {
       // Use helper method to build REST API URL for the specific path
       const apiUrl = this.buildRestApiUrl('self', path);
 
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -1335,7 +1378,7 @@ export class SignalKClient extends EventEmitter {
     });
 
     try {
-      const response = await fetch(url, this.buildFetchOptions());
+      const response = await this.fetchJson(url);
       if (!response.ok) {
         const detail = await response.text().catch(() => '');
         const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
@@ -1539,7 +1582,7 @@ export class SignalKClient extends EventEmitter {
     });
 
     try {
-      const response = await fetch(url, this.buildFetchOptions());
+      const response = await this.fetchJson(url);
       if (!response.ok) {
         const detail = await response.text().catch(() => '');
         const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -19,6 +19,7 @@ import type {
   HistoryPathsResponse,
   HistoryContextsResponse,
   CourseStatusResponse,
+  AutopilotStatusResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -260,6 +261,29 @@ export class SignalKClient extends EventEmitter {
       course,
       calcValues,
       timestamp: now(),
+    };
+  }
+
+  /**
+   * Autopilot status (read-only): engaged / state / mode / target plus the
+   * available states, modes and actions. Reads the default device, or the given
+   * pilotId. target is converted from SignalK radians to degrees. Never throws.
+   */
+  async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
+    // STUB - real implementation follows in the next commit.
+    void pilotId;
+    return {
+      available: false,
+      connected: this.connected,
+      pilotId: null,
+      pilotIds: [],
+      engaged: null,
+      state: null,
+      mode: null,
+      targetDegrees: null,
+      targetRadians: null,
+      options: null,
+      timestamp: new Date().toISOString(),
     };
   }
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -194,14 +194,72 @@ export class SignalKClient extends EventEmitter {
    * calcValues:null when not navigating. Never throws.
    */
   async getCourseStatus(): Promise<CourseStatusResponse> {
-    // STUB - real implementation follows in the next commit.
+    const now = () => new Date().toISOString();
+    let course: any = null;
+
+    // 1) Read the course root - the source of truth for whether a destination
+    //    is set. It returns 200 with null fields when not navigating.
+    try {
+      const response = await this.fetchJson(this.buildCourseApiUrl());
+      if (!response.ok) {
+        const s = response.status;
+        const error =
+          s === 404 || s === 501
+            ? `Course API not available on this SignalK server (HTTP ${s})`
+            : s === 401 || s === 403
+              ? `Course API requires authentication - set SIGNALK_TOKEN (HTTP ${s})`
+              : `Course request failed (HTTP ${s})`;
+        return {
+          available: false,
+          connected: this.connected,
+          navigating: false,
+          course: null,
+          calcValues: null,
+          timestamp: now(),
+          error,
+        };
+      }
+      course = await response.json();
+    } catch (error: any) {
+      console.error('Failed to fetch course status via HTTP:', error.message);
+      return {
+        available: false,
+        connected: this.connected,
+        navigating: false,
+        course: null,
+        calcValues: null,
+        timestamp: now(),
+        error: `Course request failed: ${error?.message || String(error)}`,
+      };
+    }
+
+    const navigating = !!(course && (course.activeRoute || course.nextPoint));
+
+    // 2) Only fetch calc values when navigating; /calcValues returns HTTP 400
+    //    ("No active destination!") otherwise, which is a normal state, not an
+    //    error - so we never even ask for it when there is no destination.
+    let calcValues: any = null;
+    if (navigating) {
+      try {
+        const response = await this.fetchJson(
+          this.buildCourseApiUrl('calcValues'),
+        );
+        if (response.ok) {
+          calcValues = await response.json();
+        }
+        // A non-ok response (e.g. a 400 race) just leaves calcValues null.
+      } catch {
+        // Leave calcValues null; the course root already answered the question.
+      }
+    }
+
     return {
-      available: false,
+      available: true,
       connected: this.connected,
-      navigating: false,
-      course: null,
-      calcValues: null,
-      timestamp: new Date().toISOString(),
+      navigating,
+      course,
+      calcValues,
+      timestamp: now(),
     };
   }
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -18,6 +18,7 @@ import type {
   HistoryDataPoint,
   HistoryPathsResponse,
   HistoryContextsResponse,
+  CourseStatusResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -174,6 +175,34 @@ export class SignalKClient extends EventEmitter {
     const queryString = query.toString();
     const suffix = queryString ? `?${queryString}` : '';
     return `${this.buildHttpUrl()}/signalk/v2/api/history/${endpoint}${suffix}`;
+  }
+
+  /**
+   * Build a SignalK v2 course API URL (under .../navigation/course).
+   * @param endpoint - '' for the course root, or 'calcValues'
+   */
+  buildCourseApiUrl(endpoint: string = ''): string {
+    const suffix = endpoint ? `/${endpoint}` : '';
+    return `${this.buildHttpUrl()}/signalk/v2/api/vessels/self/navigation/course${suffix}`;
+  }
+
+  /**
+   * Current navigation course: active route / destination plus calculated values
+   * (cross-track error, bearing, ETA, VMG, time-to-go). Reads /navigation/course
+   * (the source of truth for whether a destination is set) and, only when one is
+   * active, /navigation/course/calcValues. Returns navigating:false with
+   * calcValues:null when not navigating. Never throws.
+   */
+  async getCourseStatus(): Promise<CourseStatusResponse> {
+    // STUB - real implementation follows in the next commit.
+    return {
+      available: false,
+      connected: this.connected,
+      navigating: false,
+      course: null,
+      calcValues: null,
+      timestamp: new Date().toISOString(),
+    };
   }
 
   /**

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -12,6 +12,12 @@ import type {
   ConnectionStatus,
   AvailablePathsResponse,
   PathValueResponse,
+  HistoryQueryOptions,
+  HistoryResponse,
+  HistorySeries,
+  HistoryDataPoint,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -1257,6 +1263,295 @@ export class SignalKClient extends EventEmitter {
         timestamp: new Date().toISOString(),
         error: `HTTP fetch failed: ${error.message}, using cached value`,
       };
+    }
+  }
+
+  /**
+   * Query aggregated historical time-series for one or more SignalK paths.
+   *
+   * Hits the SignalK v2 History API (/signalk/v2/api/history/values) and folds
+   * its tabular response into per-path series. Unlike getPathValue there is NO
+   * cache fallback - history has no live cache. The method never throws; it
+   * always returns a HistoryResponse whose `available` flag tells callers
+   * whether a history provider answered.
+   *
+   * @param options - paths plus a time window (from/to or duration), resolution
+   *                  in SECONDS, optional default aggregate, and context
+   * @returns HistoryResponse with `series` (one entry per response column) and a
+   *          convenience `values` map keyed by path
+   */
+  async getHistory(options: HistoryQueryOptions): Promise<HistoryResponse> {
+    // Normalize and coerce paths to strings up front so stray non-string input
+    // from untyped isolate code can never throw before the request is built.
+    const rawPaths = Array.isArray(options?.paths) ? options.paths : [options?.paths];
+    const requestedPaths = rawPaths
+      .filter((p) => p !== undefined && p !== null)
+      .map((p) => String(p));
+
+    const empty = (available: boolean, error?: string): HistoryResponse => ({
+      available,
+      connected: this.connected,
+      resolution: options?.resolution,
+      requestedPaths,
+      series: [],
+      values: {},
+      missingPaths: requestedPaths.map((p) => p.split(':')[0]),
+      timestamp: new Date().toISOString(),
+      ...(error ? { error } : {}),
+    });
+
+    if (requestedPaths.length === 0) {
+      return empty(true, 'Invalid history query: at least one path is required');
+    }
+
+    // Validate the time window. The server requires at least one of `from` or
+    // `duration`; a missing/`to`-only window or a non-ISO time is a client
+    // error, reported distinctly from a missing provider and without a request.
+    const from = this.normalizeIso(options.from);
+    if (options.from !== undefined && from === undefined) {
+      return empty(true, 'Invalid history query: "from" must be an ISO-8601 time (e.g. 2026-06-11T06:00:00Z)');
+    }
+    const to = this.normalizeIso(options.to);
+    if (options.to !== undefined && to === undefined) {
+      return empty(true, 'Invalid history query: "to" must be an ISO-8601 time (e.g. 2026-06-11T12:00:00Z)');
+    }
+    const duration = options.duration !== undefined ? String(options.duration) : undefined;
+    if (from === undefined && duration === undefined) {
+      return empty(true, 'Invalid history query: provide "from" or "duration"');
+    }
+
+    const pathsParam = requestedPaths
+      .map((p) => this.composeHistoryPath(p, options.aggregate))
+      .join(',');
+
+    const url = this.buildHistoryApiUrl('values', {
+      context: options.context ?? this.context,
+      paths: pathsParam,
+      from,
+      to,
+      duration,
+      resolution: options.resolution,
+      provider: options.provider,
+    });
+
+    try {
+      const response = await fetch(url, this.buildFetchOptions());
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
+        return empty(available, error);
+      }
+      const body: any = await response.json();
+      return this.transformHistoryValues(body, requestedPaths, options.resolution);
+    } catch (error: any) {
+      console.error('Failed to fetch history values via HTTP:', error.message);
+      const { available, error: message } = this.classifyHistoryFailure(undefined, error?.message || String(error));
+      return empty(available, message);
+    }
+  }
+
+  /**
+   * List SignalK paths that have historical data in a time window.
+   * @returns HistoryPathsResponse; `available:false` means no history provider
+   */
+  async listHistoryPaths(
+    options: { from?: string; to?: string; duration?: string | number; context?: string } = {},
+  ): Promise<HistoryPathsResponse> {
+    const r = await this.fetchHistoryStringList('paths', options);
+    return {
+      available: r.available,
+      connected: this.connected,
+      count: r.items.length,
+      paths: r.items,
+      timestamp: new Date().toISOString(),
+      ...(r.error ? { error: r.error } : {}),
+    };
+  }
+
+  /**
+   * List vessel contexts that have historical data in a time window.
+   * @returns HistoryContextsResponse; `available:false` means no history provider
+   */
+  async listHistoryContexts(
+    options: { from?: string; to?: string; duration?: string | number } = {},
+  ): Promise<HistoryContextsResponse> {
+    const r = await this.fetchHistoryStringList('contexts', options);
+    return {
+      available: r.available,
+      connected: this.connected,
+      count: r.items.length,
+      contexts: r.items,
+      timestamp: new Date().toISOString(),
+      ...(r.error ? { error: r.error } : {}),
+    };
+  }
+
+  /**
+   * Build one entry of the comma-separated `paths` param. A path may already
+   * carry an inline aggregation method (path:method[:param]); if so it is left
+   * untouched. Otherwise an optional default `aggregate` is applied - but never
+   * to navigation.position (the server aggregates positions with "first").
+   */
+  private composeHistoryPath(pathExpr: string, aggregate?: string): string {
+    const hasInlineMethod = pathExpr.split(':').length >= 2;
+    if (hasInlineMethod || !aggregate) {
+      return pathExpr;
+    }
+    if (pathExpr === 'navigation.position') {
+      return pathExpr;
+    }
+    return `${pathExpr}:${aggregate}`;
+  }
+
+  /**
+   * Coerce a time input to an ISO-8601 string. Accepts a Date or epoch-ms
+   * number; passes a valid ISO-ish string through; returns undefined for input
+   * that cannot be a real instant (so the caller can report a clear error).
+   */
+  private normalizeIso(value: unknown): string | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      return isNaN(value.getTime()) ? undefined : value.toISOString();
+    }
+    if (typeof value === 'number') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? undefined : d.toISOString();
+    }
+    if (typeof value === 'string') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? undefined : value;
+    }
+    return undefined;
+  }
+
+  /**
+   * Map an HTTP status (or network error) to history availability + message.
+   * 404/501 or a network error means no provider is installed (available:false).
+   * 400/422 means the provider exists but the request was bad (available:true).
+   * 401/403 means the provider exists but needs auth (available:true).
+   */
+  private classifyHistoryFailure(
+    status: number | undefined,
+    detail: string,
+  ): { available: boolean; error: string } {
+    const suffix = detail ? `: ${detail}` : '';
+    if (status === 404 || status === 501) {
+      return {
+        available: false,
+        error: `History API not available - no history provider installed on the SignalK server (HTTP ${status})`,
+      };
+    }
+    if (status === 400 || status === 422) {
+      return { available: true, error: `Invalid history query (HTTP ${status})${suffix}` };
+    }
+    if (status === 401 || status === 403) {
+      return {
+        available: true,
+        error: `History API requires authentication - set SIGNALK_TOKEN (HTTP ${status})`,
+      };
+    }
+    return {
+      available: false,
+      error: `History API request failed${status ? ` (HTTP ${status})` : ''}${suffix}`,
+    };
+  }
+
+  /**
+   * Convert the server's tabular history response into per-path series. The
+   * response `values` array is authoritative: column i+1 of each data row maps
+   * to values[i].path. We iterate the response columns (never the request) so
+   * reordered, duplicate, or absent paths are handled correctly.
+   */
+  private transformHistoryValues(
+    body: any,
+    requestedPaths: string[],
+    resolution?: number,
+  ): HistoryResponse {
+    const columns: Array<{ path: string; method: string }> = Array.isArray(body?.values)
+      ? body.values
+      : [];
+    const rows: any[][] = Array.isArray(body?.data) ? body.data : [];
+
+    const series: HistorySeries[] = columns.map((col, i) => ({
+      path: col?.path,
+      method: col?.method,
+      points: rows.map(
+        (row): HistoryDataPoint => ({
+          timestamp: row?.[0],
+          value: row?.[i + 1] ?? null,
+        }),
+      ),
+    }));
+
+    // Convenience map keyed by path; the last method wins on duplicate paths
+    // (use `series` to keep every column).
+    const values: Record<string, HistoryDataPoint[]> = {};
+    for (const s of series) {
+      values[s.path] = s.points;
+    }
+
+    const returnedPaths = new Set(columns.map((c) => c?.path));
+    const missingPaths = requestedPaths
+      .map((p) => p.split(':')[0])
+      .filter((p) => !returnedPaths.has(p));
+
+    return {
+      available: true,
+      connected: this.connected,
+      context: body?.context,
+      range: body?.range,
+      resolution,
+      requestedPaths,
+      series,
+      values,
+      missingPaths,
+      rowCount: rows.length,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Shared fetch + degradation handling for the history list endpoints
+   * (paths/contexts), which both return a JSON array of strings.
+   */
+  private async fetchHistoryStringList(
+    endpoint: 'paths' | 'contexts',
+    options: { from?: string; to?: string; duration?: string | number; context?: string },
+  ): Promise<{ available: boolean; items: string[]; error?: string }> {
+    const from = this.normalizeIso(options.from);
+    const to = this.normalizeIso(options.to);
+    // The list endpoints scope to a time window; default to the last 24h when
+    // the caller gives neither `from` nor `duration` so the result is not empty.
+    const duration =
+      options.duration !== undefined
+        ? String(options.duration)
+        : from === undefined
+          ? 'PT24H'
+          : undefined;
+
+    const url = this.buildHistoryApiUrl(endpoint, {
+      context: options.context,
+      from,
+      to,
+      duration,
+    });
+
+    try {
+      const response = await fetch(url, this.buildFetchOptions());
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
+        return { available, items: [], error };
+      }
+      const body: any = await response.json();
+      const items: string[] = Array.isArray(body) ? body : [];
+      return { available: true, items };
+    } catch (error: any) {
+      console.error(`Failed to fetch history ${endpoint} via HTTP:`, error.message);
+      const { available, error: message } = this.classifyHistoryFailure(undefined, error?.message || String(error));
+      return { available, items: [], error: message };
     }
   }
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -270,10 +270,13 @@ export class SignalKClient extends EventEmitter {
    * pilotId. target is converted from SignalK radians to degrees. Never throws.
    */
   async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
-    // STUB - real implementation follows in the next commit.
-    void pilotId;
-    return {
-      available: false,
+    const now = () => new Date().toISOString();
+    const base = `${this.buildHttpUrl()}/signalk/v2/api/vessels/self/autopilots`;
+    const empty = (
+      available: boolean,
+      extra: Partial<AutopilotStatusResponse> = {},
+    ): AutopilotStatusResponse => ({
+      available,
       connected: this.connected,
       pilotId: null,
       pilotIds: [],
@@ -283,8 +286,105 @@ export class SignalKClient extends EventEmitter {
       targetDegrees: null,
       targetRadians: null,
       options: null,
-      timestamp: new Date().toISOString(),
-    };
+      timestamp: now(),
+      ...extra,
+    });
+
+    // 1) List autopilot devices: a keyed object { id: { provider, isDefault } }.
+    let devices: Record<string, any> = {};
+    try {
+      const response = await this.fetchJson(base);
+      if (!response.ok) {
+        const s = response.status;
+        const error =
+          s === 404 || s === 501
+            ? `Autopilot API not available on this SignalK server (HTTP ${s})`
+            : s === 401 || s === 403
+              ? `Autopilot API requires authentication - set SIGNALK_TOKEN (HTTP ${s})`
+              : `Autopilot request failed (HTTP ${s})`;
+        return empty(false, { error });
+      }
+      devices = (await response.json()) || {};
+    } catch (error: any) {
+      console.error('Failed to fetch autopilots via HTTP:', error.message);
+      return empty(false, {
+        error: `Autopilot request failed: ${error?.message || String(error)}`,
+      });
+    }
+
+    const pilotIds = Object.keys(devices);
+    if (pilotIds.length === 0) {
+      return empty(true);
+    }
+
+    // 2) Resolve which device to read: explicit pilotId, else isDefault, else
+    //    the documented default provider, else the first device.
+    let chosen: string;
+    if (pilotId) {
+      chosen = pilotId;
+    } else {
+      const byFlag = pilotIds.find((id) => devices[id]?.isDefault);
+      if (byFlag) {
+        chosen = byFlag;
+      } else {
+        let viaDefault: string | undefined;
+        try {
+          const res = await this.fetchJson(`${base}/_providers/_default`);
+          if (res.ok) {
+            const d: any = await res.json();
+            if (d?.id && pilotIds.includes(d.id)) {
+              viaDefault = d.id;
+            }
+          }
+        } catch {
+          // Ignore; fall back to the first device below.
+        }
+        chosen = viaDefault ?? pilotIds[0];
+      }
+    }
+    if (!pilotIds.includes(chosen)) {
+      return empty(true, {
+        pilotIds,
+        error: `Autopilot '${chosen}' not found; available: ${pilotIds.join(', ')}`,
+      });
+    }
+
+    // 3) Read the chosen device's status.
+    try {
+      const response = await this.fetchJson(
+        `${base}/${encodeURIComponent(chosen)}`,
+      );
+      if (!response.ok) {
+        return empty(true, {
+          pilotId: chosen,
+          pilotIds,
+          error: `Autopilot '${chosen}' status unavailable (HTTP ${response.status})`,
+        });
+      }
+      const dev: any = await response.json();
+      const targetRadians = typeof dev?.target === 'number' ? dev.target : null;
+      return {
+        available: true,
+        connected: this.connected,
+        pilotId: chosen,
+        pilotIds,
+        engaged: typeof dev?.engaged === 'boolean' ? dev.engaged : null,
+        state: dev?.state ?? null,
+        mode: dev?.mode ?? null,
+        targetRadians,
+        targetDegrees:
+          targetRadians !== null ? targetRadians * (180 / Math.PI) : null,
+        options: dev?.options ?? null,
+        timestamp: now(),
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch autopilot status via HTTP:', error.message);
+      return empty(true, {
+        pilotId: chosen,
+        pilotIds,
+        error: `Autopilot status request failed: ${error?.message || String(error)}`,
+      });
+    }
   }
 
   /**

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,7 +270,7 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(10);
+      expect(result.tools).toHaveLength(11);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
@@ -280,6 +280,7 @@ describe('SignalKMCPServer', () => {
         'get_history',
         'list_history_paths',
         'list_history_contexts',
+        'get_course_status',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,13 +270,16 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(7);
+      expect(result.tools).toHaveLength(10);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
         'get_active_alarms',
         'list_available_paths',
         'get_path_value',
+        'get_history',
+        'list_history_paths',
+        'list_history_contexts',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,7 +270,7 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(11);
+      expect(result.tools).toHaveLength(12);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
@@ -281,6 +281,7 @@ describe('SignalKMCPServer', () => {
         'list_history_paths',
         'list_history_contexts',
         'get_course_status',
+        'get_autopilot_status',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -476,6 +476,26 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_autopilot_status',
+        description:
+          'Get autopilot status (read-only): whether it is engaged, its state and ' +
+          'mode, the target heading (in degrees), and the available states / modes ' +
+          '/ actions. Reads the default autopilot, or pass pilotId for a specific ' +
+          'device. Returns available:false when there is no autopilot API. This ' +
+          'does NOT control the autopilot.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pilotId: {
+              type: 'string',
+              description:
+                'Optional autopilot device id (defaults to the vessel default)',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -552,7 +572,7 @@ export class SignalKMCPServer {
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
             'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
-            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(). ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(), await getAutopilotStatus(pilotId?). ' +
             'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
@@ -627,7 +647,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus(), getAutopilotStatus()`,
               );
           }
         } catch (error: any) {

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -462,6 +462,20 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_course_status',
+        description:
+          'Get the current navigation course: the active route/destination plus ' +
+          'calculated values (cross-track error, bearing to the next waypoint, ETA, ' +
+          'velocity made good, time-to-go). Returns navigating:false with ' +
+          'calcValues:null when no destination is set. Requires a SignalK v2 server. ' +
+          'Check result.available.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -538,7 +552,7 @@ export class SignalKMCPServer {
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
             'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
-            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options). ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(). ' +
             'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
@@ -613,7 +627,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus()`,
               );
           }
         } catch (error: any) {

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -374,6 +374,94 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_history',
+        description:
+          'Query aggregated historical time-series for one or more SignalK paths. ' +
+          'Requires a SignalK server with a history provider (e.g. signalk-to-influxdb); ' +
+          'if none is installed the result has available:false. ' +
+          'Times are ISO-8601 (e.g. 2026-06-11T06:00:00Z); resolution is in SECONDS; ' +
+          'provide "from" or "duration". Aggregation can be set inline per path ' +
+          '(e.g. "navigation.speedOverGround:max"). Returns a per-path map of ' +
+          '{timestamp, value} points; navigation.position values are [longitude, latitude] ' +
+          'arrays (NOT {latitude, longitude}), and null marks a gap. Best used inside ' +
+          'execute_code so you can aggregate before returning.\n\n' +
+          'Example:\n' +
+          '```javascript\n' +
+          '(async () => {\n' +
+          "  const h = await getHistory({ paths: 'navigation.speedOverGround:max', from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300 });\n" +
+          '  if (!h.available) return JSON.stringify({ note: h.error });\n' +
+          "  const pts = h.values['navigation.speedOverGround'].filter(p => p.value != null);\n" +
+          '  return JSON.stringify({ maxKn: (Math.max(...pts.map(p => p.value)) * 1.94384).toFixed(1) });\n' +
+          '})();\n' +
+          '```',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            paths: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'SignalK path(s), optionally with an inline aggregation method (path:method[:param]), ' +
+                'e.g. ["navigation.speedOverGround:sma:5", "navigation.position"]',
+            },
+            from: {
+              type: 'string',
+              description: 'ISO-8601 start time (provide "from" or "duration")',
+            },
+            to: { type: 'string', description: 'ISO-8601 end time (defaults to now)' },
+            duration: {
+              type: 'string',
+              description: 'ISO-8601 duration (PT1H) or seconds; use instead of "from"',
+            },
+            resolution: {
+              type: 'number',
+              description: 'Bucket size in SECONDS (e.g. 60 = 1-minute buckets)',
+            },
+            aggregate: {
+              type: 'string',
+              description:
+                'Default aggregation for bare paths: average|min|max|first|last (default average)',
+            },
+            context: { type: 'string', description: 'Vessel context (default vessels.self)' },
+          },
+          required: ['paths'],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'list_history_paths',
+        description:
+          'List SignalK paths that have historical data in a time window. ' +
+          'Returns available:false when no history provider is installed. ' +
+          'Defaults to the last 24 hours when no time window is given.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'ISO-8601 start time' },
+            to: { type: 'string', description: 'ISO-8601 end time' },
+            duration: { type: 'string', description: 'ISO-8601 duration (P1D) or seconds' },
+            context: { type: 'string', description: 'Vessel context filter' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'list_history_contexts',
+        description:
+          'List vessel contexts that have historical data in a time window. ' +
+          'Returns available:false when no history provider is installed. ' +
+          'Useful to discover which vessels have history before calling get_history.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'ISO-8601 start time' },
+            to: { type: 'string', description: 'ISO-8601 end time' },
+            duration: { type: 'string', description: 'ISO-8601 duration (P1D) or seconds' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -449,7 +537,9 @@ export class SignalKMCPServer {
             'Execute JavaScript code in a secure V8 isolate with access to SignalK SDK functions. ' +
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
-            'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(). ' +
+            'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options). ' +
+            'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
           inputSchema: {
@@ -523,7 +613,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts()`,
               );
           }
         } catch (error: any) {

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -474,6 +474,9 @@ describe('Tool Migration Tests', () => {
             'execute_code',
             'get_initial_context',
             'get_connection_status',
+            'get_history',
+            'list_history_paths',
+            'list_history_contexts',
           ].includes(t.name)
       );
 

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -85,6 +85,7 @@ jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
 
 import { SignalKMCPServer } from './signalk-mcp-server.js';
 import { SignalKClient } from './signalk-client.js';
+import { SignalKBinding } from './bindings/signalk-binding.js';
 
 // Mock the SignalK client
 jest.mock('./signalk-client', () => ({
@@ -553,6 +554,35 @@ describe('Tool Migration Tests', () => {
 
       // Should be valid async IIFE pattern
       expect(code.trim().endsWith('})();')).toBe(true);
+    });
+  });
+
+  describe('Tool/binding parity', () => {
+    // Direct-only utility tools: handled by the server, not exposed inside the
+    // isolate as SDK functions that call the binding.
+    const DIRECT_ONLY = ['execute_code', 'get_initial_context'];
+    const toCamelCase = (s: string): string =>
+      s.replace(/_([a-z])/g, (_m: string, c: string) => c.toUpperCase());
+
+    it('every tool definition has a matching camelCase method on SignalKBinding', () => {
+      new SignalKMCPServer({ executionMode: 'hybrid' });
+      const listToolsHandler = mockServer.setRequestHandler.mock.calls.find(
+        (call) => call[0] === 'ListToolsRequestSchema'
+      )?.[1] as any;
+      const tools = listToolsHandler().tools as Array<{ name: string }>;
+
+      const bindingMethods = Object.getOwnPropertyNames(
+        SignalKBinding.prototype
+      );
+      const missing = tools
+        .map((t) => t.name)
+        .filter((name) => !DIRECT_ONLY.includes(name))
+        .filter((name) => !bindingMethods.includes(toCamelCase(name)));
+
+      // The isolate SDK is auto-generated from tool names via the same
+      // camelCase rule (generator.ts); a tool without a matching binding method
+      // would be a broken SDK function inside execute_code.
+      expect(missing).toEqual([]);
     });
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,12 @@ export type {
   AvailablePathsResponse,
   PathValueResponse,
   ConnectionStatus,
+  HistoryDataPoint,
+  HistoryQueryOptions,
+  HistorySeries,
+  HistoryResponse,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,7 @@ export type {
   HistoryPathsResponse,
   HistoryContextsResponse,
   CourseStatusResponse,
+  AutopilotStatusResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export type {
   HistoryResponse,
   HistoryPathsResponse,
   HistoryContextsResponse,
+  CourseStatusResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -154,3 +154,17 @@ export interface HistoryContextsResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface CourseStatusResponse {
+  available: boolean;
+  connected: boolean;
+  // false when there is no active destination / route
+  navigating: boolean;
+  // the raw /navigation/course body (activeRoute, nextPoint, arrivalCircle, ...)
+  course: any | null;
+  // /navigation/course/calcValues (distance, bearing, ETA, cross-track error,
+  // VMG, time-to-go) - null when not navigating or unavailable
+  calcValues: any | null;
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -169,3 +169,23 @@ export interface CourseStatusResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface AutopilotStatusResponse {
+  available: boolean;
+  connected: boolean;
+  // the autopilot device that was read (the default, or the requested pilotId)
+  pilotId: string | null;
+  // ids of all autopilot devices on the vessel
+  pilotIds: string[];
+  engaged: boolean | null;
+  state: string | null;
+  mode: string | null;
+  // target heading converted to degrees, or null when there is no target
+  targetDegrees: number | null;
+  // raw target heading in radians (SignalK SI), or null
+  targetRadians: number | null;
+  // available states / modes / actions for the device
+  options: any;
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -80,3 +80,77 @@ export interface PathValueResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface HistoryDataPoint {
+  timestamp: string;
+  // Aggregated value for one time bucket. May be a scalar (number / string /
+  // boolean), a position [longitude, latitude] array (GeoJSON order, unlike the
+  // live API's {latitude, longitude}), or null for a gap with no data.
+  value: number | number[] | string | boolean | null;
+}
+
+export interface HistoryQueryOptions {
+  // One or more SignalK paths. Each entry may include an inline aggregation
+  // method: 'path', 'path:method', or 'path:method:param'
+  // (e.g. 'navigation.speedOverGround:sma:5').
+  paths: string | string[];
+  // ISO-8601 start time. At least one of `from` or `duration` is required.
+  from?: string;
+  // ISO-8601 end time (defaults to now on the server).
+  to?: string;
+  // ISO-8601 duration ('PT1H') or whole seconds; use instead of `from`/`to`.
+  duration?: string | number;
+  // Bucket size in SECONDS (not milliseconds).
+  resolution?: number;
+  // Default aggregation method applied to bare paths (e.g. 'average', 'max').
+  aggregate?: string;
+  // Vessel context (default 'vessels.self').
+  context?: string;
+  // Optional history provider id (e.g. 'signalk-to-influxdb2').
+  provider?: string;
+}
+
+export interface HistorySeries {
+  path: string;
+  method: string;
+  points: HistoryDataPoint[];
+}
+
+export interface HistoryResponse {
+  // True when the history provider answered (even if the window was empty).
+  // False only when no history provider is installed/reachable.
+  available: boolean;
+  connected: boolean;
+  context?: string;
+  range?: { from: string; to: string };
+  resolution?: number;
+  requestedPaths: string[];
+  // One entry per response column, in server order (never lossy).
+  series: HistorySeries[];
+  // Convenience map keyed by path. If the same path is requested with two
+  // methods, the last one wins here - use `series` to keep both.
+  values: Record<string, HistoryDataPoint[]>;
+  // Requested paths the server returned no column for.
+  missingPaths: string[];
+  rowCount?: number;
+  timestamp: string;
+  error?: string;
+}
+
+export interface HistoryPathsResponse {
+  available: boolean;
+  connected: boolean;
+  count: number;
+  paths: string[];
+  timestamp: string;
+  error?: string;
+}
+
+export interface HistoryContextsResponse {
+  available: boolean;
+  connected: boolean;
+  count: number;
+  contexts: string[];
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -160,11 +160,12 @@ export interface CourseStatusResponse {
   connected: boolean;
   // false when there is no active destination / route
   navigating: boolean;
-  // the raw /navigation/course body (activeRoute, nextPoint, arrivalCircle, ...)
-  course: any | null;
+  // the raw /navigation/course body (activeRoute, nextPoint, arrivalCircle, ...),
+  // or null when unavailable
+  course: any;
   // /navigation/course/calcValues (distance, bearing, ETA, cross-track error,
-  // VMG, time-to-go) - null when not navigating or unavailable
-  calcValues: any | null;
+  // VMG, time-to-go), or null when not navigating or unavailable
+  calcValues: any;
   timestamp: string;
   error?: string;
 }

--- a/tests/signalk-client-history.e2e.spec.ts
+++ b/tests/signalk-client-history.e2e.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * SignalK Client History API Integration Tests
+ *
+ * Exercises getHistory/listHistoryPaths/listHistoryContexts against a live
+ * SignalK server. The History API needs a history provider plugin (for example
+ * signalk-to-influxdb); these tests probe for it in beforeAll and SKIP
+ * gracefully (still passing) when it is absent, so they do not fail on a vanilla
+ * server such as the Docker CI image (which runs with DISABLEPLUGINS=true).
+ *
+ * To run against a history-enabled server, point SIGNALK_HOST/PORT/TLS at it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { SignalKClient } from '../src/signalk-client.js';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('SignalK Client History API - Live Integration', () => {
+  let client: SignalKClient;
+  let historyEnabled = false;
+  let knownPaths: string[] = [];
+
+  const CONNECTION_TIMEOUT = 30000;
+
+  beforeAll(async () => {
+    client = new SignalKClient({
+      hostname: process.env.SIGNALK_HOST,
+      port: parseInt(process.env.SIGNALK_PORT || '3000'),
+      useTLS: process.env.SIGNALK_TLS === 'true',
+      context: process.env.SIGNALK_CONTEXT || 'vessels.self',
+    });
+
+    try {
+      await client.connect();
+    } catch (error) {
+      console.log(
+        `History tests skipped - could not reach a SignalK server: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    // Probe for a history provider. available:false means none is installed.
+    const contexts = await client.listHistoryContexts();
+    if (!contexts.available) {
+      console.log(
+        'History tests skipped - SignalK server has no history provider installed',
+      );
+      return;
+    }
+    historyEnabled = true;
+
+    const paths = await client.listHistoryPaths();
+    knownPaths = paths.paths || [];
+    console.log(
+      `History provider present; ${knownPaths.length} historized paths found`,
+    );
+  }, CONNECTION_TIMEOUT);
+
+  afterAll(() => {
+    if (client && client.connected) {
+      client.disconnect();
+    }
+  });
+
+  test('listHistoryPaths reports an available provider and an array of paths', () => {
+    if (!historyEnabled) {
+      return; // skipped - no provider on this server
+    }
+    expect(Array.isArray(knownPaths)).toBe(true);
+  });
+
+  test(
+    'getHistory returns a bounded per-path series for a recent window',
+    async () => {
+      if (!historyEnabled) {
+        return; // skipped - no provider on this server
+      }
+
+      const preferred = [
+        'navigation.speedOverGround',
+        'navigation.position',
+      ].filter((p) => knownPaths.includes(p));
+      const target = preferred[0] || knownPaths[0];
+      if (!target) {
+        console.log('No historized paths to query - skipping');
+        return;
+      }
+
+      const to = new Date();
+      const from = new Date(to.getTime() - 60 * 60 * 1000); // last hour
+
+      const h = await client.getHistory({
+        paths: target,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        resolution: 300,
+      });
+
+      expect(h.available).toBe(true);
+      expect(h.requestedPaths).toContain(target);
+      expect(Array.isArray(h.series)).toBe(true);
+      // Bounded result: ~12 buckets for one hour at 300s, never the full table.
+      expect(typeof h.rowCount).toBe('number');
+      expect(h.rowCount as number).toBeLessThan(1000);
+
+      if (h.series.length > 0) {
+        const points = h.values[h.series[0].path];
+        expect(Array.isArray(points)).toBe(true);
+        if (points.length > 0) {
+          expect(points[0]).toHaveProperty('timestamp');
+          expect(points[0]).toHaveProperty('value');
+        }
+      }
+    },
+    CONNECTION_TIMEOUT,
+  );
+});


### PR DESCRIPTION
**Branch:** `read-course-autopilot` → targets `main` · **Stack position:** 2 of 12

## Stack & merge order

Part of a stack of read-only additions. Each branch builds on the one below it, and the
bottom of the stack builds on **#9 `feat/history-api`** (already open here, not yet merged).

GitHub only lets a PR target a branch that exists in this repository, and these parent
branches aren't on `main` yet — so **every PR in this stack targets `main`**, and its diff
currently includes the commits of everything beneath it. **Please review and merge them
bottom-up:** each PR's diff collapses to just its own changes once the PRs below it land.
(This PR is step 2; its diff is its own changes plus steps 1–1 and #9.)

| Step | PR | Branch |
|------|----|--------|
| prereq | #9 | `feat/history-api` — open here, **not yet merged** |
| 1 | #11 | `reliability-foundation` |
| 2 | #12 | `read-course-autopilot` ⬅ **this PR** |
| 3 | #13 | `read-weather` |
| 4 | #14 | `tools-mode-dispatch` |
| 5 | #15 | `standardize-example-coordinates` |
| 6 | #16 | `server-feature-discovery` |
| 7 | #17 | `anchor-watch-docs` |
| 8 | #18 | `alarm-enrichment` |
| 9 | #19 | `resources-reads` |
| 10 | #20 | `radar-targets` |
| 11 | #21 | `unified-targets` |
| 12 | #22 | `units-metadata-docs` |

---
## Summary

Two read-only navigation/steering capabilities exposed to `execute_code`:
the active course (destination + calculated values) and autopilot status
(engaged/state/mode/target). Both read the SignalK v2 API, return raw SI
values, and degrade gracefully instead of throwing.

## What changed

### `getCourseStatus()`
- Reads `/signalk/v2/api/vessels/self/navigation/course` (the source of truth
  for whether a destination is set) and, only when navigating, `/calcValues`
  (cross-track error, bearing, ETA, VMG, time-to-go).
- When no destination is set the course root returns nulls → `navigating:false`,
  `calcValues:null`, and `calcValues` is never even requested.
- A `400 "No active destination!"` from `/calcValues` is treated as a normal
  not-navigating state, not an error (a course-specific classifier, separate
  from the history one).

### `getAutopilotStatus(pilotId?)`
- Lists the autopilot devices (a **keyed object**, not an array). Empty list →
  `available:true` with no devices.
- Picks the device: explicit `pilotId` → the one flagged `isDefault` →
  `_providers/_default` → the first device.
- Reads the chosen device and converts `target` radians → degrees **only when a
  target is set** (standby reports `null`). Reports both radians and degrees.

Both add the response type, binding delegation, tool definition, and
`mcp-tool-reference.json` entry. Missing API / auth failure / unreachable device
all return a clear `available`/`error` shape.

## Testing

- 5 course tests (not-navigating, navigating merge, the 400 edge, 404, network)
  and 7 autopilot tests (no devices, default via `isDefault`, radians→degrees,
  `_providers/_default` fallback, explicit id, 404, network).
- `npm run typecheck`, `npm run test:unit`, `npm run lint` all clean.

## Notes

- Read-only. Autopilot control (engage/heading/tack) is explicitly **not** here.
- Values are raw SI; convert in-isolate (the tool-reference examples show it).

## Commits

```
Add getCourseStatus with failing tests (red)
Implement getCourseStatus (green)
Add getAutopilotStatus with failing tests (red)
Implement getAutopilotStatus (green)
```
