### PR TITLE
Enrich active alarms with method[] and status{}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ docker/signalk-config/*
 # Test results
 test-results/
 
+# Local-only reference: SignalK API specs downloaded from a live server.
+# Kept out of git so no server host / vessel data is ever committed.
+docs/signalk-api-specs/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the SignalK MCP Server project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **SignalK History API support.** Three new SDK functions are available inside `execute_code`:
+  - `getHistory({ paths, from, to, duration, resolution, aggregate, context })` - query aggregated historical time-series for one or more paths.
+  - `listHistoryPaths(options?)` - list paths that have history in a time window.
+  - `listHistoryContexts(options?)` - list vessels that have history.
+- Queries the SignalK v2 History API (`/signalk/v2/api/history/...`) and reshapes the tabular response into easy per-path lists of `{ timestamp, value }` points, so agent code can summarize thousands of rows down to a few numbers inside the isolate.
+- Notes for callers: times are ISO-8601 and `resolution` is in **seconds**; aggregation can be set inline per path (e.g. `navigation.speedOverGround:max`); `navigation.position` history values are `[longitude, latitude]` arrays (unlike the live API's `{latitude, longitude}`); and `null` marks a data gap.
+- Requires a SignalK server with a history provider (e.g. `signalk-to-influxdb`). When none is installed, the functions return `available: false` instead of failing, so code-execution mode keeps working.
+
 ## [1.0.8] - 2025-11-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ const heading = await getPathValue({ path: "navigation.headingTrue" });
 
 // Connection status - ALSO requires await!
 const status = await getConnectionStatus();
+
+// Recorded history over a time range (see "Historical Data" below)
+const past = await getHistory({ paths: 'navigation.speedOverGround', from: '2026-06-11T06:00:00Z', resolution: 300 });
+const historyPaths = await listHistoryPaths();    // which paths have history
 ```
 
 ### Real-time Marine Data
@@ -229,6 +233,136 @@ SERVER_VERSION=1.0.6
 ```
 
 **Result:** ~300 tokens (vs 13,000 with 3 separate tool calls!)
+
+## Historical Data (History API)
+
+The SDK functions above return **live** values. The History API lets the AI look at **recorded** data over time - your track from this morning, how the wind built over the afternoon, how much the batteries drained overnight. As with everything else, the code runs in the isolate, so the AI can boil thousands of recorded points down to a few numbers before any of it reaches the model.
+
+### Requirements
+
+History is recorded by a separate SignalK plugin, so the requirements are on your **SignalK server** (not on this MCP server):
+
+- **SignalK Server 2.15 or newer** (this is where the v2 History API lives).
+- **A history provider plugin that is installed and recording**, most commonly [`signalk-to-influxdb`](https://www.npmjs.com/package/@signalk/signalk-to-influxdb) writing to an InfluxDB database. (`signalk-to-timescaledb` works too.)
+
+If no provider is installed, the history functions still return safely with `available: false` - they never break code execution mode.
+
+### Setup (on the SignalK server)
+
+1. In the SignalK admin web page, open **Appstore → Available** and install **signalk-to-influxdb** (plus an InfluxDB database for it to write to - many boat setups already run one).
+2. Turn the plugin on and let it record for a while so there is some history to query.
+3. Point this MCP server at that SignalK server the usual way (`SIGNALK_HOST` / `SIGNALK_PORT` / `SIGNALK_TLS`). If your server needs a login to read history, set `SIGNALK_TOKEN`.
+
+To check at any time whether history is turned on:
+
+```javascript
+(async () => {
+  const probe = await listHistoryContexts();
+  return JSON.stringify({ historyAvailable: probe.available });
+})()
+```
+
+### History SDK functions
+
+```javascript
+// Query recorded values for one or more paths over a time range
+const h = await getHistory({
+  paths: 'navigation.speedOverGround',  // a path, or an array of paths
+  from: '2026-06-11T06:00:00Z',         // ISO-8601; give "from" or "duration"
+  to:   '2026-06-11T12:00:00Z',         // ISO-8601 (optional, defaults to now)
+  resolution: 300                        // bucket size in SECONDS (300 = 5 min)
+});
+
+// Discover what is recorded
+const paths    = await listHistoryPaths();     // which paths have history
+const contexts = await listHistoryContexts();  // which vessels have history
+```
+
+**Good to know:**
+
+- **Times are ISO-8601** (like `2026-06-11T06:00:00Z`) and **`resolution` is in seconds**, not milliseconds.
+- Pick an **aggregation method per path** by adding it to the path: `'navigation.speedOverGround:max'` or `'environment.wind.speedApparent:sma:5'`. The default is `average` (and `first` for position).
+- `getHistory` returns `{ available, values, series, rowCount }`. `values` is grouped by path, so `values['navigation.speedOverGround']` is a list of `{ timestamp, value }`.
+- **Positions are `[longitude, latitude]` arrays** in history (the live API uses `{ latitude, longitude }`). `null` means there was no data in that bucket - drop nulls before averaging.
+- Always check **`available`** first. `available: false` means no history provider is installed on the server.
+
+### Sample use cases
+
+| Ask | What the code does in the isolate |
+|-----|-----------------------------------|
+| "How far did we sail today, and our average speed while moving?" | Adds up speed over time for distance; ignores time at the dock |
+| "How did the wind build this afternoon?" | Averages wind into short steps and reports the trend and biggest gust |
+| "Show this morning's track" | Pulls position history and thins it down to a handful of waypoints |
+| "How much did the batteries drain overnight?" | Totals battery current over the night into a simple energy summary |
+| "When will we need to refuel?" | Fits a line through tank-level history to estimate burn rate and days left |
+| "Any engine temperature spikes today?" | Scans engine-temp history for spikes and time at high RPM |
+| "What was the roughest weather in the last two days?" | Finds the peak wind and the barometer trend |
+| "The low-battery alarm just fired - what led up to it?" | Pulls the 30 minutes before the alarm and finds where the voltage dropped |
+
+### Example 5: Distance sailed today
+
+**Query:** "How far have we sailed today, and what's our average speed while moving?"
+
+**Code:**
+```javascript
+(async () => {
+  const h = await getHistory({
+    paths: 'navigation.speedOverGround',
+    from: '2026-06-11T00:00:00Z',
+    to:   '2026-06-11T23:59:59Z',
+    resolution: 60                       // 1-minute buckets
+  });
+  if (!h.available) return JSON.stringify({ note: h.error });
+
+  const points = h.values['navigation.speedOverGround'].filter(p => p.value != null);
+
+  let meters = 0, movingMinutes = 0;
+  for (const p of points) {
+    meters += p.value * 60;              // speed (m/s) over a 60s bucket
+    if (p.value > 0.26) movingMinutes++; // moving if faster than ~0.5 knots
+  }
+  const movingHours = movingMinutes / 60;
+
+  return JSON.stringify({
+    distanceNm: (meters / 1852).toFixed(1),
+    movingHours: movingHours.toFixed(1),
+    avgKnotsWhileMoving: movingHours
+      ? ((meters / (movingHours * 3600)) * 1.94384).toFixed(1)
+      : '0'
+  });
+})()
+```
+
+**Result:** A 3-number summary instead of ~1,400 raw speed readings.
+
+### Example 6: This morning's track
+
+**Query:** "Show me the route we took this morning."
+
+**Code:**
+```javascript
+(async () => {
+  const h = await getHistory({
+    paths: 'navigation.position',        // recorded as [longitude, latitude]
+    from: '2026-06-11T06:00:00Z',
+    to:   '2026-06-11T12:00:00Z',
+    resolution: 120                      // a fix every 2 minutes
+  });
+  if (!h.available) return JSON.stringify({ note: h.error });
+
+  const track = h.values['navigation.position']
+    .filter(p => p.value != null)
+    .map(p => ({ lon: p.value[0], lat: p.value[1], time: p.timestamp })); // [lon, lat]!
+
+  return JSON.stringify({
+    fixes: track.length,
+    start: track[0],
+    end: track[track.length - 1]
+  });
+})()
+```
+
+**Result:** A short list of waypoints instead of thousands of position fixes.
 
 ## Development
 

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -104,6 +104,27 @@
         "description": "Read-only autopilot status: engaged/state/mode/target plus the available states, modes and actions. With no pilotId it picks the default device. Target is reported in both radians and degrees.",
         "returns": "{ available, pilotId, pilotIds, engaged, state, mode, targetDegrees, targetRadians, options }. pilotIds lists every autopilot device. targetDegrees/targetRadians are null when no target is set (e.g. standby). available:false means the autopilot API is unavailable.",
         "example": "(async () => {\n  const ap = await getAutopilotStatus();\n  if (!ap.available) return JSON.stringify({ note: ap.error });\n  return JSON.stringify({ pilot: ap.pilotId, engaged: ap.engaged, state: ap.state, mode: ap.mode, headingDeg: ap.targetDegrees == null ? null : ap.targetDegrees.toFixed(0) });\n})()"
+      },
+      "getWeatherObservations": {
+        "signature": "await getWeatherObservations(options?)",
+        "description": "Current weather observations for the vessel position (air/water temperature, wind, pressure, humidity, waves, current). Resolves the vessel position first - lat/lon are required by the weather API - and does NOT fire the request when there is no fix. Values are SI: temperatures in kelvin, speeds in m/s, directions in radians, pressure in pascals.",
+        "parameters": "options (all optional): { latitude, longitude } to query a point other than the vessel; provider (weather provider id, defaults to the server default); count (max entries); date (YYYY-MM-DD start).",
+        "returns": "{ available, kind:'observations', position, provider, data, count }. data is the raw array of observations. available:false with reason:'no vessel position' when there is no fix; available:false with error when there is no weather provider.",
+        "example": "(async () => {\n  const w = await getWeatherObservations();\n  if (!w.available) return JSON.stringify({ note: w.reason || w.error });\n  const o = w.data[0] || {};\n  return JSON.stringify({ airC: o.outside?.temperature == null ? null : (o.outside.temperature - 273.15).toFixed(1), windKn: o.wind?.speedTrue == null ? null : (o.wind.speedTrue * 1.94384).toFixed(1) });\n})()"
+      },
+      "getWeatherForecast": {
+        "signature": "await getWeatherForecast({ type, latitude, longitude, provider, count, date })",
+        "description": "Weather forecast for the vessel position. type is 'daily' (per-day summary) or 'point' (per time-point series); defaults to 'daily'. Same position handling and SI units as getWeatherObservations.",
+        "parameters": "options (all optional): type ('daily'|'point'); latitude/longitude to query elsewhere; provider; count (max entries); date (YYYY-MM-DD start).",
+        "returns": "{ available, kind:'forecast', forecastType, position, provider, data, count }. data is the raw array of forecast entries. available:false with reason:'no vessel position' when there is no fix.",
+        "example": "(async () => {\n  const f = await getWeatherForecast({ type: 'daily', count: 3 });\n  if (!f.available) return JSON.stringify({ note: f.reason || f.error });\n  return JSON.stringify({ days: f.data.map(d => ({ date: d.date, highC: d.outside?.temperature == null ? null : (d.outside.temperature - 273.15).toFixed(0) })) });\n})()"
+      },
+      "getWeatherWarnings": {
+        "signature": "await getWeatherWarnings(options?)",
+        "description": "Active weather warnings for the vessel position (e.g. gale or storm advisories). Same position handling as getWeatherObservations.",
+        "parameters": "options (all optional): { latitude, longitude } to query elsewhere; provider.",
+        "returns": "{ available, kind:'warnings', position, provider, data, count }. data is the list of warnings (each { startTime, endTime, source, type, details }); count 0 means none. available:false with reason:'no vessel position' when there is no fix.",
+        "example": "(async () => {\n  const w = await getWeatherWarnings();\n  if (!w.available) return JSON.stringify({ note: w.reason || w.error });\n  return JSON.stringify({ count: w.count, warnings: w.data.map(x => x.type) });\n})()"
       }
     }
   },

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -65,6 +65,33 @@
         "note": "This function is also async - MUST use await",
         "returns": "Object with connected, url, hostname, port, context, timestamp",
         "example": "const status = await getConnectionStatus();\nconsole.log('Connected:', status.connected);"
+      },
+      "getHistory": {
+        "signature": "await getHistory({ paths, from, to, duration, resolution, aggregate, context })",
+        "description": "Query aggregated historical time-series for one or more SignalK paths. Requires a SignalK history provider (e.g. signalk-to-influxdb).",
+        "parameters": {
+          "paths": "Path string or array of paths; add an inline aggregation method as path:method[:param], e.g. 'navigation.speedOverGround:sma:5'",
+          "from": "ISO-8601 start time; provide 'from' or 'duration'",
+          "to": "ISO-8601 end time (defaults to now)",
+          "duration": "ISO-8601 duration (PT1H) or seconds; use instead of 'from'",
+          "resolution": "Bucket size in SECONDS (not milliseconds), e.g. 60 for 1-minute buckets",
+          "aggregate": "Default method for bare paths: average|min|max|first|last (default average)",
+          "context": "Vessel context (default vessels.self)"
+        },
+        "returns": "{ available, values: { '<path>': [{ timestamp, value }] }, series, missingPaths, rowCount }. Check 'available' (false = no history provider). null marks a data gap. navigation.position values are [longitude, latitude] ARRAYS, unlike live getVesselState which uses {latitude, longitude}.",
+        "example": "(async () => {\n  const h = await getHistory({ paths: 'navigation.speedOverGround:max', from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300 });\n  if (!h.available) return JSON.stringify({ note: h.error });\n  const pts = h.values['navigation.speedOverGround'].filter(p => p.value != null);\n  return JSON.stringify({ maxKn: (Math.max(...pts.map(p => p.value)) * 1.94384).toFixed(1) });\n})()"
+      },
+      "listHistoryPaths": {
+        "signature": "await listHistoryPaths(options?)",
+        "description": "List SignalK paths that have historical data in a time window. Defaults to the last 24 hours.",
+        "returns": "{ available, count, paths: string[] }. available:false means no history provider.",
+        "example": "const h = await listHistoryPaths();\nif (h.available) console.log(h.paths.length, 'historized paths');"
+      },
+      "listHistoryContexts": {
+        "signature": "await listHistoryContexts(options?)",
+        "description": "List vessel contexts that have historical data. Call before get_history to discover which vessels have history.",
+        "returns": "{ available, count, contexts: string[] }",
+        "example": "const h = await listHistoryContexts();\nif (h.available) console.log(h.contexts);"
       }
     }
   },
@@ -116,7 +143,11 @@
     "units": "All SignalK values use SI units (meters, seconds, Kelvin, radians)",
     "timestamps": "All data includes RFC 3339 timestamps for freshness checking",
     "missing_data": "Paths may not exist if sensors/systems not installed",
-    "null_values": "Null values indicate sensor offline or no valid reading"
+    "null_values": "Null values indicate sensor offline or no valid reading",
+    "history_times": "History query times are ISO-8601 only; resolution is in SECONDS (not milliseconds)",
+    "history_positions": "In history results, navigation.position is a [longitude, latitude] array - NOT the {latitude, longitude} object that live getVesselState/getPathValue return",
+    "history_gaps": "In history results, null marks a time bucket with no data - filter nulls before averaging or integrating",
+    "history_availability": "get_history/list_history_* return available:false when the SignalK server has no history provider installed"
   },
   "legacy_tools": {
     "status": "DEPRECATED - Available only in 'tools' or 'hybrid' mode",

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -158,6 +158,14 @@
       "Use execute_code with getPathValue() for specific diagnostics"
     ]
   },
+  "recipes": {
+    "description": "Ready-made execute_code snippets that combine existing functions",
+    "anchor_watch": {
+      "purpose": "Check whether the vessel is dragging anchor",
+      "how": "No special function is needed - read the navigation.anchor.* paths with getPathValue. Compare navigation.anchor.currentRadius (current distance from where the anchor was dropped) against navigation.anchor.maxRadius (the alarm radius / set scope). Both are in metres. currentRadius at or beyond maxRadius means the boat has swung outside its set scope and may be dragging. The values are null when no anchor watch is set.",
+      "example": "(async () => {\n  const cur = await getPathValue('navigation.anchor.currentRadius');\n  const max = await getPathValue('navigation.anchor.maxRadius');\n  const current = cur.data?.value ?? null;\n  const limit = max.data?.value ?? null;\n  if (current == null || limit == null) return JSON.stringify({ anchorWatch: false, note: 'no anchor watch set' });\n  return JSON.stringify({ currentM: Math.round(current), maxM: Math.round(limit), dragging: current > limit, marginM: Math.round(limit - current) });\n})()"
+    }
+  },
   "efficiency_guidelines": {
     "filter_in_isolate": "Always filter/transform data in the isolate before returning",
     "combine_calls": "Make multiple SDK calls in a single execute_code invocation",

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -98,6 +98,12 @@
         "description": "Current navigation course: active route/destination plus calculated values (cross-track error, bearing, ETA, VMG, time-to-go). Values are SI (distance in metres, bearings in radians).",
         "returns": "{ available, navigating, course, calcValues }. navigating is false (and calcValues null) when no destination is set. available:false means the course API is unavailable.",
         "example": "(async () => {\n  const c = await getCourseStatus();\n  if (!c.available) return JSON.stringify({ note: c.error });\n  if (!c.navigating) return JSON.stringify({ navigating: false });\n  return JSON.stringify({ distanceNm: (c.calcValues.distance / 1852).toFixed(2), bearingDeg: (c.calcValues.bearingTrue * 57.2958).toFixed(0) });\n})()"
+      },
+      "getAutopilotStatus": {
+        "signature": "await getAutopilotStatus(pilotId?)",
+        "description": "Read-only autopilot status: engaged/state/mode/target plus the available states, modes and actions. With no pilotId it picks the default device. Target is reported in both radians and degrees.",
+        "returns": "{ available, pilotId, pilotIds, engaged, state, mode, targetDegrees, targetRadians, options }. pilotIds lists every autopilot device. targetDegrees/targetRadians are null when no target is set (e.g. standby). available:false means the autopilot API is unavailable.",
+        "example": "(async () => {\n  const ap = await getAutopilotStatus();\n  if (!ap.available) return JSON.stringify({ note: ap.error });\n  return JSON.stringify({ pilot: ap.pilotId, engaged: ap.engaged, state: ap.state, mode: ap.mode, headingDeg: ap.targetDegrees == null ? null : ap.targetDegrees.toFixed(0) });\n})()"
       }
     }
   },

--- a/resources/mcp-tool-reference.json
+++ b/resources/mcp-tool-reference.json
@@ -92,6 +92,12 @@
         "description": "List vessel contexts that have historical data. Call before get_history to discover which vessels have history.",
         "returns": "{ available, count, contexts: string[] }",
         "example": "const h = await listHistoryContexts();\nif (h.available) console.log(h.contexts);"
+      },
+      "getCourseStatus": {
+        "signature": "await getCourseStatus()",
+        "description": "Current navigation course: active route/destination plus calculated values (cross-track error, bearing, ETA, VMG, time-to-go). Values are SI (distance in metres, bearings in radians).",
+        "returns": "{ available, navigating, course, calcValues }. navigating is false (and calcValues null) when no destination is set. available:false means the course API is unavailable.",
+        "example": "(async () => {\n  const c = await getCourseStatus();\n  if (!c.available) return JSON.stringify({ note: c.error });\n  if (!c.navigating) return JSON.stringify({ navigating: false });\n  return JSON.stringify({ distanceNm: (c.calcValues.distance / 1852).toFixed(2), bearingDeg: (c.calcValues.bearingTrue * 57.2958).toFixed(0) });\n})()"
       }
     }
   },

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -10,6 +10,7 @@ import type {
   HistoryResponse,
   HistoryPathsResponse,
   HistoryContextsResponse,
+  CourseStatusResponse,
 } from '../types/index.js';
 
 /**
@@ -224,6 +225,21 @@ export class SignalKBinding {
     duration?: string | number;
   }): Promise<HistoryContextsResponse> {
     return this.client.listHistoryContexts(options);
+  }
+
+  /**
+   * Current navigation course - active route / destination plus calculated
+   * values (cross-track error, bearing, ETA, VMG, time-to-go).
+   *
+   * @returns CourseStatusResponse; available:false if the course API is
+   *   unavailable, navigating:false when no destination is set.
+   *
+   * @example
+   * const c = await signalk.getCourseStatus();
+   * if (c.navigating) console.log('XTE:', c.calcValues?.crossTrackError);
+   */
+  async getCourseStatus(): Promise<CourseStatusResponse> {
+    return this.client.getCourseStatus();
   }
 
   /**

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -11,6 +11,7 @@ import type {
   HistoryPathsResponse,
   HistoryContextsResponse,
   CourseStatusResponse,
+  AutopilotStatusResponse,
 } from '../types/index.js';
 
 /**
@@ -240,6 +241,22 @@ export class SignalKBinding {
    */
   async getCourseStatus(): Promise<CourseStatusResponse> {
     return this.client.getCourseStatus();
+  }
+
+  /**
+   * Autopilot status (read-only) - engaged / state / mode / target plus the
+   * available states, modes and actions.
+   *
+   * @param pilotId - optional device id; defaults to the vessel's default pilot
+   * @returns AutopilotStatusResponse; available:false if the autopilot API is
+   *   unavailable.
+   *
+   * @example
+   * const ap = await signalk.getAutopilotStatus();
+   * console.log(ap.engaged, ap.state, ap.targetDegrees);
+   */
+  async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
+    return this.client.getAutopilotStatus(pilotId);
   }
 
   /**

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -6,6 +6,10 @@ import type {
   AvailablePathsResponse,
   PathValueResponse,
   ConnectionStatus,
+  HistoryQueryOptions,
+  HistoryResponse,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from '../types/index.js';
 
 /**
@@ -173,6 +177,53 @@ export class SignalKBinding {
   async getPathValue(pathOrOptions: string | { path: string }): Promise<PathValueResponse> {
     const path = typeof pathOrOptions === 'string' ? pathOrOptions : pathOrOptions.path;
     return this.client.getPathValue(path);
+  }
+
+  /**
+   * Query historical time-series for one or more SignalK paths.
+   *
+   * Requires a SignalK server with a history provider (e.g. signalk-to-influxdb).
+   * Returns per-path arrays of { timestamp, value }. All times are ISO-8601 and
+   * `resolution` is in SECONDS. navigation.position values are [lon, lat] arrays.
+   * Check `available` - it is false when no history provider is installed.
+   *
+   * @example
+   * // In agent code
+   * const h = await signalk.getHistory({
+   *   paths: 'navigation.speedOverGround:max',
+   *   from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300
+   * });
+   * if (h.available) {
+   *   const sog = h.values['navigation.speedOverGround'].filter(p => p.value != null);
+   * }
+   */
+  async getHistory(options: HistoryQueryOptions): Promise<HistoryResponse> {
+    return this.client.getHistory(options);
+  }
+
+  /**
+   * List SignalK paths that have historical data in a time window.
+   * @returns HistoryPathsResponse; available:false means no history provider
+   */
+  async listHistoryPaths(options?: {
+    from?: string;
+    to?: string;
+    duration?: string | number;
+    context?: string;
+  }): Promise<HistoryPathsResponse> {
+    return this.client.listHistoryPaths(options);
+  }
+
+  /**
+   * List vessel contexts that have historical data in a time window.
+   * @returns HistoryContextsResponse; available:false means no history provider
+   */
+  async listHistoryContexts(options?: {
+    from?: string;
+    to?: string;
+    duration?: string | number;
+  }): Promise<HistoryContextsResponse> {
+    return this.client.listHistoryContexts(options);
   }
 
   /**

--- a/src/bindings/signalk-binding.ts
+++ b/src/bindings/signalk-binding.ts
@@ -12,6 +12,8 @@ import type {
   HistoryContextsResponse,
   CourseStatusResponse,
   AutopilotStatusResponse,
+  WeatherQueryOptions,
+  WeatherResponse,
 } from '../types/index.js';
 
 /**
@@ -257,6 +259,65 @@ export class SignalKBinding {
    */
   async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
     return this.client.getAutopilotStatus(pilotId);
+  }
+
+  /**
+   * Current weather observations for the vessel's position (read-only).
+   *
+   * Requires a SignalK server with a weather provider. lat/lon are required by
+   * the server, so the vessel's position is resolved first; with no position
+   * fix the request is not sent and available:false / reason is returned.
+   * Values are SI (temperatures in kelvin, speeds in m/s, directions in rad).
+   *
+   * @param options - optional position override, provider, count, date
+   * @returns WeatherResponse; available:false when the weather API or a
+   *   position fix is unavailable.
+   *
+   * @example
+   * const w = await signalk.getWeatherObservations();
+   * if (w.available) console.log('air °C:', w.data[0]?.outside?.temperature - 273.15);
+   */
+  async getWeatherObservations(
+    options?: WeatherQueryOptions,
+  ): Promise<WeatherResponse> {
+    return this.client.getWeatherObservations(options);
+  }
+
+  /**
+   * Weather forecast for the vessel's position (read-only).
+   *
+   * type selects the 'daily' (per-day) or 'point' (per time-point) forecast.
+   * Like observations, the vessel position is resolved first and the request is
+   * skipped when there is no fix. Values are SI.
+   *
+   * @param options - type ('daily' | 'point') plus optional position, provider,
+   *   count, date
+   * @returns WeatherResponse; available:false when unavailable.
+   *
+   * @example
+   * const f = await signalk.getWeatherForecast({ type: 'daily', count: 3 });
+   */
+  async getWeatherForecast(
+    options?: WeatherQueryOptions,
+  ): Promise<WeatherResponse> {
+    return this.client.getWeatherForecast(options);
+  }
+
+  /**
+   * Active weather warnings for the vessel's position (read-only).
+   *
+   * @param options - optional position override, provider
+   * @returns WeatherResponse; data is the list of warnings (empty when none).
+   *   available:false when the weather API or a position fix is unavailable.
+   *
+   * @example
+   * const w = await signalk.getWeatherWarnings();
+   * if (w.available && w.count) console.log(w.data.map(x => x.type));
+   */
+  async getWeatherWarnings(
+    options?: WeatherQueryOptions,
+  ): Promise<WeatherResponse> {
+    return this.client.getWeatherWarnings(options);
   }
 
   /**

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -750,6 +750,64 @@ describe('SignalKClient', () => {
       expect(alarms.alarms[0].state).toBe('alert');
     });
 
+    test('includes notification method[] and status{} when present', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            notifications: {
+              mob: {
+                value: {
+                  state: 'emergency',
+                  message: 'Man overboard',
+                  method: ['visual', 'sound'],
+                  status: {
+                    silenced: false,
+                    acknowledged: false,
+                    canSilence: true,
+                  },
+                },
+                timestamp: '2026-06-12T00:00:00.000Z',
+              },
+            },
+          }),
+      } as Response);
+
+      const alarms = await client.getActiveAlarms();
+
+      expect(alarms.alarms).toHaveLength(1);
+      const a = alarms.alarms[0];
+      expect(a.method).toEqual(['visual', 'sound']);
+      expect(a.status).toEqual({
+        silenced: false,
+        acknowledged: false,
+        canSilence: true,
+      });
+      // Backward compatible: the existing fields are unchanged.
+      expect(a.state).toBe('emergency');
+      expect(a.message).toBe('Man overboard');
+    });
+
+    test('omits method/status when the notification has neither', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            notifications: {
+              test: {
+                value: { state: 'alert', message: 'Test alarm' },
+                timestamp: '2026-06-12T00:00:00.000Z',
+              },
+            },
+          }),
+      } as Response);
+
+      const alarms = await client.getActiveAlarms();
+      const a = alarms.alarms[0];
+      expect(a.method).toBeUndefined();
+      expect(a.status).toBeUndefined();
+    });
+
     test('should return connection status correctly', () => {
       client.connected = true;
 

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -44,9 +44,11 @@ describe('SignalKClient', () => {
     delete process.env.SIGNALK_TOKEN;
     delete process.env.SIGNALK_CONTEXT;
 
-    // Clear mocks
+    // Clear mocks. mockReset (not just mockClear) also drains the
+    // mockResolvedValueOnce queue, so an unconsumed queued response from one
+    // test can never bleed into the next.
     jest.clearAllMocks();
-    mockFetch.mockClear();
+    mockFetch.mockReset();
 
     // Get the mock constructor using dynamic import
     mockSignalKClient = {
@@ -2187,6 +2189,163 @@ describe('SignalKClient', () => {
       mockFetch.mockRejectedValueOnce(new Error('network down'));
       const r = await client.getAutopilotStatus();
       expect(r.available).toBe(false);
+    });
+  });
+
+  describe('Weather Methods', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    const ok = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const err = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve(''),
+      } as Response);
+
+    // Scrubbed fixtures (synthetic position + values, no real data).
+    // The vessel-state fetch returns the raw self tree that getVesselState
+    // flattens into data['navigation.position'].value.
+    const selfWithPosition = {
+      navigation: { position: { value: { latitude: 12, longitude: 34 } } },
+    };
+    const selfNoPosition = { navigation: {} };
+    const observations = [
+      {
+        date: '2026-06-12T00:00:00.000Z',
+        type: 'observation',
+        outside: { temperature: 290, pressure: 101000 },
+        wind: { speedTrue: 5, directionTrue: 1.2 },
+      },
+    ];
+    const warnings = [
+      {
+        startTime: '2026-06-12T00:00:00.000Z',
+        endTime: '2026-06-12T06:00:00.000Z',
+        type: 'Gale Warning',
+        details: 'test advisory',
+      },
+    ];
+
+    test('explicit position: requests /observations with lat/lon, parses data', async () => {
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      const w = await client.getWeatherObservations({
+        latitude: 12,
+        longitude: 34,
+      });
+      expect(w.available).toBe(true);
+      expect(w.kind).toBe('observations');
+      expect(w.count).toBe(1);
+      expect(w.data).toEqual(observations);
+      expect(w.position).toEqual({ latitude: 12, longitude: 34 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+      expect(url).toContain('/signalk/v2/api/weather/observations');
+      expect(url).toContain('lat=12');
+      expect(url).toContain('lon=34');
+    });
+
+    test('resolves the vessel position first, then requests weather', async () => {
+      mockFetch.mockResolvedValueOnce(ok(selfWithPosition));
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      const w = await client.getWeatherObservations();
+      expect(w.available).toBe(true);
+      expect(w.position).toEqual({ latitude: 12, longitude: 34 });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0][0] as string).toContain(
+        '/signalk/v1/api/vessels/self',
+      );
+      expect(decodeURIComponent(mockFetch.mock.calls[1][0] as string)).toContain(
+        '/weather/observations',
+      );
+    });
+
+    test('no vessel position => available:false, reason, weather never fetched', async () => {
+      mockFetch.mockResolvedValueOnce(ok(selfNoPosition));
+      const w = await client.getWeatherObservations();
+      expect(w.available).toBe(false);
+      expect(w.reason).toMatch(/position/i);
+      expect(w.data).toEqual([]);
+      // Only the vessel-state probe fired; the weather request never did.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('provider and count are passed through to the query', async () => {
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      await client.getWeatherObservations({
+        latitude: 12,
+        longitude: 34,
+        provider: 'open-meteo',
+        count: 3,
+      });
+      const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+      expect(url).toContain('provider=open-meteo');
+      expect(url).toContain('count=3');
+    });
+
+    test('weather API unavailable (404) => available:false', async () => {
+      mockFetch.mockResolvedValueOnce(err(404));
+      const w = await client.getWeatherObservations({
+        latitude: 12,
+        longitude: 34,
+      });
+      expect(w.available).toBe(false);
+    });
+
+    test('forecast defaults to the daily endpoint', async () => {
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      const w = await client.getWeatherForecast({ latitude: 12, longitude: 34 });
+      expect(w.available).toBe(true);
+      expect(w.kind).toBe('forecast');
+      expect(w.forecastType).toBe('daily');
+      expect(decodeURIComponent(mockFetch.mock.calls[0][0] as string)).toContain(
+        '/weather/forecasts/daily',
+      );
+    });
+
+    test("forecast type 'point' hits the point endpoint", async () => {
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      const w = await client.getWeatherForecast({
+        latitude: 12,
+        longitude: 34,
+        type: 'point',
+      });
+      expect(w.forecastType).toBe('point');
+      expect(decodeURIComponent(mockFetch.mock.calls[0][0] as string)).toContain(
+        '/weather/forecasts/point',
+      );
+    });
+
+    test('warnings: requests /warnings and returns the list', async () => {
+      mockFetch.mockResolvedValueOnce(ok(warnings));
+      const w = await client.getWeatherWarnings({
+        latitude: 12,
+        longitude: 34,
+      });
+      expect(w.available).toBe(true);
+      expect(w.kind).toBe('warnings');
+      expect(w.count).toBe(1);
+      expect(w.data).toEqual(warnings);
+      expect(decodeURIComponent(mockFetch.mock.calls[0][0] as string)).toContain(
+        '/weather/warnings',
+      );
+    });
+
+    test('network error => available:false, no throw', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const w = await client.getWeatherWarnings({
+        latitude: 12,
+        longitude: 34,
+      });
+      expect(w.available).toBe(false);
     });
   });
 

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -2081,6 +2081,115 @@ describe('SignalKClient', () => {
     });
   });
 
+  describe('getAutopilotStatus', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    const ok = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const err = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve(''),
+      } as Response);
+
+    const deviceOffline = {
+      options: { states: [], modes: [], actions: [] },
+      state: 'standby',
+      mode: null,
+      target: null,
+      engaged: false,
+    };
+    const deviceEngaged = {
+      options: { states: [], modes: [], actions: [] },
+      state: 'auto',
+      mode: 'compass',
+      target: Math.PI / 2,
+      engaged: true,
+    };
+
+    test('no autopilot devices => available:true, empty', async () => {
+      mockFetch.mockResolvedValueOnce(ok({}));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(true);
+      expect(r.pilotIds).toEqual([]);
+      expect(r.pilotId).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('default device picked via isDefault; offline target stays null', async () => {
+      mockFetch.mockResolvedValueOnce(
+        ok({ 'pilot-a': { isDefault: false }, 'pilot-b': { isDefault: true } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok(deviceOffline));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(true);
+      expect(r.pilotId).toBe('pilot-b');
+      expect(r.pilotIds).toEqual(['pilot-a', 'pilot-b']);
+      expect(r.engaged).toBe(false);
+      expect(r.state).toBe('standby');
+      expect(r.targetRadians).toBeNull();
+      expect(r.targetDegrees).toBeNull();
+      expect(mockFetch.mock.calls[1][0] as string).toContain(
+        '/autopilots/pilot-b',
+      );
+    });
+
+    test('target radians converted to degrees when engaged', async () => {
+      mockFetch.mockResolvedValueOnce(ok({ 'pilot-b': { isDefault: true } }));
+      mockFetch.mockResolvedValueOnce(ok(deviceEngaged));
+      const r = await client.getAutopilotStatus();
+      expect(r.engaged).toBe(true);
+      expect(r.targetRadians).toBeCloseTo(Math.PI / 2);
+      expect(r.targetDegrees).toBeCloseTo(90);
+    });
+
+    test('no isDefault => resolve via _providers/_default', async () => {
+      mockFetch.mockResolvedValueOnce(
+        ok({ 'pilot-a': { isDefault: false }, 'pilot-b': { isDefault: false } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok({ id: 'pilot-b' }));
+      mockFetch.mockResolvedValueOnce(ok(deviceOffline));
+      const r = await client.getAutopilotStatus();
+      expect(r.pilotId).toBe('pilot-b');
+      expect(mockFetch.mock.calls[1][0] as string).toContain(
+        '/_providers/_default',
+      );
+    });
+
+    test('explicit pilotId reads that device', async () => {
+      mockFetch.mockResolvedValueOnce(
+        ok({ 'pilot-a': { isDefault: true }, 'pilot-b': { isDefault: false } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok(deviceOffline));
+      const r = await client.getAutopilotStatus('pilot-b');
+      expect(r.pilotId).toBe('pilot-b');
+      expect(mockFetch.mock.calls[1][0] as string).toContain(
+        '/autopilots/pilot-b',
+      );
+    });
+
+    test('autopilot API unavailable (404) => available:false', async () => {
+      mockFetch.mockResolvedValueOnce(err(404));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(false);
+      expect(r.pilotIds).toEqual([]);
+    });
+
+    test('network error => available:false, no throw', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const r = await client.getAutopilotStatus();
+      expect(r.available).toBe(false);
+    });
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1949,6 +1949,43 @@ describe('SignalKClient', () => {
     });
   });
 
+  describe('Request reliability (timeout + retry)', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    test('a hung server times out gracefully instead of stalling the call', async () => {
+      jest.useFakeTimers();
+      try {
+        // The server "hangs": fetch only settles if its request is aborted.
+        mockFetch.mockImplementation(
+          (_url: any, init: any) =>
+            new Promise((_resolve, reject) => {
+              const signal = (init && init.signal) as AbortSignal | undefined;
+              signal?.addEventListener('abort', () =>
+                reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+              );
+            }) as any,
+        );
+
+        const pending = client.listAvailablePaths();
+        // Drive the initial timeout and the one retry.
+        await jest.advanceTimersByTimeAsync(60000);
+        const res = await pending;
+
+        expect(res.connected).toBe(false);
+        expect(typeof res.error).toBe('string');
+        expect(res.error).toMatch(/tim(e|ed)\s?out|failed/i);
+      } finally {
+        jest.useRealTimers();
+      }
+    }, 15000);
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1948,4 +1948,268 @@ describe('SignalKClient', () => {
       expect((client as any).shouldIncludeAISPath('unknown.path')).toBe(false);
     });
   });
+
+  describe('History Methods', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    // A small real-shaped fixture: two columns (a scalar + a position) and a
+    // null gap in the last row.
+    const valuesFixture = {
+      context: 'vessels.self',
+      range: { from: '2026-06-11T06:00:00.000Z', to: '2026-06-11T06:10:00.000Z' },
+      values: [
+        { path: 'navigation.speedOverGround', method: 'max' },
+        { path: 'navigation.position', method: 'first' },
+      ],
+      data: [
+        ['2026-06-11T06:00:00.000Z', 3.14, [-122.47, 37.81]],
+        ['2026-06-11T06:05:00.000Z', 0, [-122.48, 37.82]],
+        ['2026-06-11T06:10:00.000Z', null, null],
+      ],
+    };
+
+    const okJson = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const errResp = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve('boom'),
+      } as Response);
+
+    describe('buildHistoryApiUrl', () => {
+      test('targets the v2 history base and drops undefined params', () => {
+        const url = client.buildHistoryApiUrl('values', {
+          context: 'vessels.self',
+          paths: 'navigation.speedOverGround:max',
+          from: '2026-06-11T06:00:00Z',
+          to: undefined,
+          resolution: 60,
+        });
+        expect(
+          url.startsWith('http://example.com:3000/signalk/v2/api/history/values?'),
+        ).toBe(true);
+        const decoded = decodeURIComponent(url);
+        expect(decoded).toContain('paths=navigation.speedOverGround:max');
+        expect(decoded).toContain('from=2026-06-11T06:00:00Z');
+        expect(decoded).toContain('resolution=60'); // seconds, not ms
+        expect(url).not.toContain('to='); // undefined dropped
+      });
+    });
+
+    describe('getHistory transform', () => {
+      test('maps each response column to its path by index, keeping nulls and [lon,lat]', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        const h = await client.getHistory({
+          paths: ['navigation.speedOverGround:max', 'navigation.position:first'],
+          from: '2026-06-11T06:00:00Z',
+          to: '2026-06-11T06:10:00Z',
+          resolution: 300,
+        });
+        expect(h.available).toBe(true);
+        expect(h.rowCount).toBe(3);
+        const sog = h.values['navigation.speedOverGround'];
+        expect(sog.map((p) => p.value)).toEqual([3.14, 0, null]); // 0 kept, null strict
+        const pos = h.values['navigation.position'];
+        expect(pos[0].value).toEqual([-122.47, 37.81]); // array passthrough
+        expect(pos[2].value).toBeNull();
+        expect(h.series).toHaveLength(2);
+        expect(h.series[1].method).toBe('first');
+        expect(h.missingPaths).toEqual([]);
+      });
+
+      test('keys by RESPONSE order, not request order', async () => {
+        const shuffled = {
+          ...valuesFixture,
+          values: [
+            { path: 'navigation.position', method: 'first' },
+            { path: 'navigation.speedOverGround', method: 'max' },
+          ],
+          data: [['2026-06-11T06:00:00.000Z', [-1, 2], 9.9]],
+        };
+        mockFetch.mockResolvedValueOnce(okJson(shuffled));
+        const h = await client.getHistory({
+          paths: ['navigation.speedOverGround', 'navigation.position'],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.values['navigation.position'][0].value).toEqual([-1, 2]);
+        expect(h.values['navigation.speedOverGround'][0].value).toBe(9.9);
+      });
+
+      test('keeps duplicate paths in series and reports missing paths', async () => {
+        const dup = {
+          context: 'vessels.self',
+          range: { from: 'a', to: 'b' },
+          values: [
+            { path: 'navigation.speedOverGround', method: 'max' },
+            { path: 'navigation.speedOverGround', method: 'min' },
+          ],
+          data: [['t', 5, 1]],
+        };
+        mockFetch.mockResolvedValueOnce(okJson(dup));
+        const h = await client.getHistory({
+          paths: [
+            'navigation.speedOverGround:max',
+            'navigation.speedOverGround:min',
+            'tanks.fuel.level',
+          ],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.series).toHaveLength(2);
+        expect(h.series[0].method).toBe('max');
+        expect(h.series[1].method).toBe('min');
+        // values map keyed by bare path - last (min) wins
+        expect(h.values['navigation.speedOverGround'][0].value).toBe(1);
+        expect(h.missingPaths).toContain('tanks.fuel.level');
+      });
+
+      test('empty data window is available:true with rowCount 0 (not unavailable)', async () => {
+        mockFetch.mockResolvedValueOnce(
+          okJson({
+            context: 'vessels.self',
+            range: { from: 'a', to: 'b' },
+            values: [{ path: 'navigation.speedOverGround', method: 'average' }],
+            data: [],
+          }),
+        );
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.rowCount).toBe(0);
+        expect(h.values['navigation.speedOverGround']).toEqual([]);
+      });
+    });
+
+    describe('paths composition', () => {
+      test('applies default aggregate to bare paths but not to inline or position', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: [
+            'navigation.speedOverGround',
+            'environment.wind.speedApparent:sma:5',
+            'navigation.position',
+          ],
+          aggregate: 'max',
+          from: '2026-06-11T06:00:00Z',
+        });
+        const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        expect(url).toContain(
+          'paths=navigation.speedOverGround:max,environment.wind.speedApparent:sma:5,navigation.position',
+        );
+      });
+
+      test('string and array paths produce the same request', async () => {
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: 'navigation.speedOverGround:max',
+          from: '2026-06-11T06:00:00Z',
+        });
+        const a = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        mockFetch.mockResolvedValueOnce(okJson(valuesFixture));
+        await client.getHistory({
+          paths: ['navigation.speedOverGround:max'],
+          from: '2026-06-11T06:00:00Z',
+        });
+        const b = decodeURIComponent(mockFetch.mock.calls[1][0] as string);
+        expect(a).toBe(b);
+      });
+    });
+
+    describe('input guards (no request sent)', () => {
+      test('missing from and duration => available:true with a clear error, no fetch', async () => {
+        const h = await client.getHistory({ paths: 'navigation.speedOverGround' });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/from.*duration/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+      test('non-ISO from => distinct error, no fetch', async () => {
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: 'yesterday',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/ISO-8601/);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+      test('no paths => clear error, no fetch', async () => {
+        const h = await client.getHistory({
+          paths: [],
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/path/i);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('graceful degradation (never throws, no cache fallback)', () => {
+      test('404 => available:false (no provider)', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(404));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(false);
+        expect(h.values).toEqual({});
+        expect(h.error).toMatch(/not available|provider/i);
+      });
+      test('400 => available:true with invalid-query error', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(400));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/invalid/i);
+      });
+      test('401 => available:true asking for auth', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(401));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(true);
+        expect(h.error).toMatch(/auth|SIGNALK_TOKEN/i);
+      });
+      test('network error => available:false, no throw', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('network down'));
+        const h = await client.getHistory({
+          paths: 'navigation.speedOverGround',
+          from: '2026-06-11T06:00:00Z',
+        });
+        expect(h.available).toBe(false);
+        expect(h.values).toEqual({});
+      });
+    });
+
+    describe('listHistoryPaths / listHistoryContexts', () => {
+      test('parse a JSON array of strings and default to a 24h window', async () => {
+        mockFetch.mockResolvedValueOnce(
+          okJson(['navigation.position', 'electrical.batteries.house.voltage']),
+        );
+        const r = await client.listHistoryPaths();
+        expect(r.available).toBe(true);
+        expect(r.count).toBe(2);
+        expect(r.paths).toContain('navigation.position');
+        const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+        expect(url).toContain('/signalk/v2/api/history/paths');
+        expect(url).toContain('duration=PT24H');
+      });
+      test('contexts 404 => available:false', async () => {
+        mockFetch.mockResolvedValueOnce(errResp(404));
+        const r = await client.listHistoryContexts();
+        expect(r.available).toBe(false);
+        expect(r.contexts).toEqual([]);
+      });
+    });
+  });
 });

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -176,8 +176,8 @@ describe('SignalKClient', () => {
         'vessels.self',
         'navigation.position',
         {
-          latitude: 37.8199,
-          longitude: -122.4783,
+          latitude: 38.9784,
+          longitude: -76.4922,
         },
       );
 
@@ -192,8 +192,8 @@ describe('SignalKClient', () => {
         'vessels.self.navigation.position',
       );
       expect(storedValue?.value).toEqual({
-        latitude: 37.8199,
-        longitude: -122.4783,
+        latitude: 38.9784,
+        longitude: -76.4922,
       });
     });
 
@@ -201,7 +201,7 @@ describe('SignalKClient', () => {
       const delta = global.testUtils.createSampleDelta(
         'vessels.urn:mrn:imo:mmsi:123456789',
         'navigation.position',
-        { latitude: 37.8299, longitude: -122.4683 },
+        { latitude: 38.9884, longitude: -76.4822 },
       );
 
       client.handleDelta(delta);
@@ -211,8 +211,8 @@ describe('SignalKClient', () => {
       const target = client.aisTargets.get('urn:mrn:imo:mmsi:123456789');
       expect(target?.mmsi).toBe('123456789'); // Now stores just the MMSI number
       expect(target?.['navigation.position']).toEqual({
-        latitude: 37.8299,
-        longitude: -122.4683,
+        latitude: 38.9884,
+        longitude: -76.4822,
       });
     });
 
@@ -316,7 +316,7 @@ describe('SignalKClient', () => {
 
       // Add some test data
       client.latestValues.set('vessels.self.navigation.position', {
-        value: { latitude: 37.8199, longitude: -122.4783 },
+        value: { latitude: 38.9784, longitude: -76.4922 },
         timestamp: '2025-06-21T10:00:00.000Z',
         source: { label: 'GPS1', type: 'NMEA0183' },
       });
@@ -345,7 +345,7 @@ describe('SignalKClient', () => {
           mmsi: '123456789',
           navigation: {
             position: {
-              value: { latitude: 37.8199, longitude: -122.4783 },
+              value: { latitude: 38.9784, longitude: -76.4922 },
               timestamp: '2025-06-21T10:00:00.000Z',
               source: { label: 'GPS1', type: 'NMEA0183' },
             },
@@ -359,8 +359,8 @@ describe('SignalKClient', () => {
       expect(state.context).toBe('vessels.self');
       expect(state.data['navigation.position']).toBeDefined();
       expect(state.data['navigation.position'].value).toEqual({
-        latitude: 37.8199,
-        longitude: -122.4783,
+        latitude: 38.9784,
+        longitude: -76.4922,
       });
       expect(state.data['name']).toBeDefined();
       expect(state.data['name'].value).toBe('Test Vessel');
@@ -373,7 +373,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.8199, longitude: -122.4783 },
+              value: { latitude: 38.9784, longitude: -76.4922 },
               timestamp: '2025-06-21T10:00:00.000Z',
               source: { label: 'GPS1', type: 'NMEA0183' },
             },
@@ -412,7 +412,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.81, longitude: -122.47 },
+              value: { latitude: 38.97, longitude: -76.49 },
               timestamp: currentTimestamp,
             },
           },
@@ -428,7 +428,7 @@ describe('SignalKClient', () => {
             name: 'Test Vessel',
             navigation: {
               position: {
-                value: { latitude: 37.82, longitude: -122.48 },
+                value: { latitude: 38.98, longitude: -76.50 },
                 timestamp: currentTimestamp,
               },
               speedOverGround: {
@@ -511,7 +511,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.81, longitude: -122.47 },
+              value: { latitude: 38.97, longitude: -76.49 },
               timestamp: currentTimestamp,
             },
           },
@@ -526,7 +526,7 @@ describe('SignalKClient', () => {
           self: {
             navigation: {
               position: {
-                value: { latitude: 37.81, longitude: -122.47 },
+                value: { latitude: 38.97, longitude: -76.49 },
                 timestamp: currentTimestamp,
               },
             },
@@ -535,7 +535,7 @@ describe('SignalKClient', () => {
           'urn:mrn:imo:mmsi:338123456': {
             navigation: {
               position: {
-                value: { latitude: 37.81, longitude: -122.47 },
+                value: { latitude: 38.97, longitude: -76.49 },
                 timestamp: currentTimestamp,
               },
             },
@@ -543,7 +543,7 @@ describe('SignalKClient', () => {
           'urn:mrn:imo:mmsi:123456789': {
             navigation: {
               position: {
-                value: { latitude: 37.82, longitude: -122.48 },
+                value: { latitude: 38.98, longitude: -76.50 },
                 timestamp: currentTimestamp,
               },
             },
@@ -551,7 +551,7 @@ describe('SignalKClient', () => {
           'urn:mrn:signalk:uuid:some-uuid': {
             navigation: {
               position: {
-                value: { latitude: 37.83, longitude: -122.49 },
+                value: { latitude: 38.99, longitude: -76.51 },
                 timestamp: currentTimestamp,
               },
             },
@@ -578,7 +578,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.81, longitude: -122.47 },
+              value: { latitude: 38.97, longitude: -76.49 },
               timestamp: recentTimestamp,
             },
           },
@@ -593,7 +593,7 @@ describe('SignalKClient', () => {
           'urn:mrn:imo:mmsi:987654321': {
             navigation: {
               position: {
-                value: { latitude: 37.82, longitude: -122.48 },
+                value: { latitude: 38.98, longitude: -76.50 },
                 timestamp: oldTimestamp,
               },
             },
@@ -601,7 +601,7 @@ describe('SignalKClient', () => {
           'urn:mrn:imo:mmsi:123456789': {
             navigation: {
               position: {
-                value: { latitude: 37.83, longitude: -122.49 },
+                value: { latitude: 38.99, longitude: -76.51 },
                 timestamp: recentTimestamp,
               },
             },
@@ -625,7 +625,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.81, longitude: -122.47 },
+              value: { latitude: 38.97, longitude: -76.49 },
               timestamp: currentTimestamp,
             },
           },
@@ -638,7 +638,7 @@ describe('SignalKClient', () => {
         vesselsData[`urn:mrn:imo:mmsi:${i.toString().padStart(9, '0')}`] = {
           navigation: {
             position: {
-              value: { latitude: 37.81 + i * 0.001, longitude: -122.47 + i * 0.001 },
+              value: { latitude: 38.97 + i * 0.001, longitude: -76.49 + i * 0.001 },
               timestamp: currentTimestamp,
             },
           },
@@ -665,7 +665,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.81, longitude: -122.47 },
+              value: { latitude: 38.97, longitude: -76.49 },
               timestamp: currentTimestamp,
             },
           },
@@ -692,7 +692,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.81, longitude: -122.47 },
+              value: { latitude: 38.97, longitude: -76.49 },
               timestamp: currentTimestamp,
             },
           },
@@ -708,7 +708,7 @@ describe('SignalKClient', () => {
             navigation: {
               position: {
                 // Approximately 1.57km away
-                value: { latitude: 37.82, longitude: -122.48 },
+                value: { latitude: 38.98, longitude: -76.50 },
                 timestamp: currentTimestamp,
               },
             },
@@ -773,7 +773,7 @@ describe('SignalKClient', () => {
     test('should fetch available paths via HTTP successfully', async () => {
       const mockResponse = {
         'navigation.position': {
-          value: { latitude: 37.8199, longitude: -122.4783 },
+          value: { latitude: 38.9784, longitude: -76.4922 },
         },
         'navigation.speedOverGround': { value: 5.2 },
         environment: {
@@ -841,7 +841,7 @@ describe('SignalKClient', () => {
     test('should use cached data when HTTP fails', async () => {
       // Set up cached data
       client.latestValues.set('vessels.self.navigation.position', {
-        value: { latitude: 37.8199, longitude: -122.4783 },
+        value: { latitude: 38.9784, longitude: -76.4922 },
         timestamp: '2025-06-21T10:00:00.000Z',
       });
 
@@ -851,8 +851,8 @@ describe('SignalKClient', () => {
 
       expect(result.error).toContain('HTTP fetch failed');
       expect(result.data.value).toEqual({
-        latitude: 37.8199,
-        longitude: -122.4783,
+        latitude: 38.9784,
+        longitude: -76.4922,
       });
     });
   });
@@ -1046,7 +1046,7 @@ describe('SignalKClient', () => {
             values: [
               {
                 path: 'navigation.position',
-                value: { latitude: 37.8199, longitude: -122.4783 },
+                value: { latitude: 38.9784, longitude: -76.4922 },
               },
             ],
           },
@@ -1261,7 +1261,7 @@ describe('SignalKClient', () => {
         json: () => Promise.resolve({
           navigation: {
             position: {
-              value: { latitude: 37.8199, longitude: -122.4783 },
+              value: { latitude: 38.9784, longitude: -76.4922 },
               timestamp: '2023-06-22T10:30:15.000Z',
             },
             speedOverGround: {
@@ -1316,8 +1316,8 @@ describe('SignalKClient', () => {
         'vessels.self.navigation.position',
       );
       expect(position?.value).toEqual({
-        latitude: 37.8199,
-        longitude: -122.4783,
+        latitude: 38.9784,
+        longitude: -76.4922,
       });
 
       expect(client.availablePaths.has('navigation.position')).toBe(true);
@@ -1644,7 +1644,7 @@ describe('SignalKClient', () => {
       client.updateAISTarget(
         vesselContext,
         'navigation.position',
-        { latitude: 37.8199, longitude: -122.4783 },
+        { latitude: 38.9784, longitude: -76.4922 },
         '2023-06-22T10:30:15.000Z',
       );
 
@@ -1652,8 +1652,8 @@ describe('SignalKClient', () => {
       const target = client.aisTargets.get(vesselId);
       expect(target).toBeDefined();
       expect(target?.['navigation.position']).toEqual({
-        latitude: 37.8199,
-        longitude: -122.4783,
+        latitude: 38.9784,
+        longitude: -76.4922,
       });
       expect(target?.lastUpdate).toBe('2023-06-22T10:30:15.000Z');
     });
@@ -1811,7 +1811,7 @@ describe('SignalKClient', () => {
             values: [
               {
                 path: 'navigation.position',
-                value: { latitude: 37.8199, longitude: -122.4783 },
+                value: { latitude: 38.9784, longitude: -76.4922 },
               },
             ],
           },
@@ -1865,7 +1865,7 @@ describe('SignalKClient', () => {
     test('should handle getPathValue with cached data fallback (line 705, 715)', async () => {
       // Add cached data
       client.latestValues.set('vessels.self.navigation.position', {
-        value: { latitude: 37.8199, longitude: -122.4783 },
+        value: { latitude: 38.9784, longitude: -76.4922 },
         timestamp: '2023-06-22T10:30:15.000Z',
         source: { label: 'GPS1', type: 'NMEA0183' },
       });
@@ -1883,8 +1883,8 @@ describe('SignalKClient', () => {
       // Verify cached data is returned (covers line 715)
       expect(result.data).toBeDefined();
       expect(result.data!.value).toEqual({
-        latitude: 37.8199,
-        longitude: -122.4783,
+        latitude: 38.9784,
+        longitude: -76.4922,
       });
       expect(result.error).toContain(
         'HTTP fetch failed: Network failure, using cached value',
@@ -2409,8 +2409,8 @@ describe('SignalKClient', () => {
         { path: 'navigation.position', method: 'first' },
       ],
       data: [
-        ['2026-06-11T06:00:00.000Z', 3.14, [-122.47, 37.81]],
-        ['2026-06-11T06:05:00.000Z', 0, [-122.48, 37.82]],
+        ['2026-06-11T06:00:00.000Z', 3.14, [-76.49, 38.97]],
+        ['2026-06-11T06:05:00.000Z', 0, [-76.50, 38.98]],
         ['2026-06-11T06:10:00.000Z', null, null],
       ],
     };
@@ -2459,7 +2459,7 @@ describe('SignalKClient', () => {
         const sog = h.values['navigation.speedOverGround'];
         expect(sog.map((p) => p.value)).toEqual([3.14, 0, null]); // 0 kept, null strict
         const pos = h.values['navigation.position'];
-        expect(pos[0].value).toEqual([-122.47, 37.81]); // array passthrough
+        expect(pos[0].value).toEqual([-76.49, 38.97]); // array passthrough
         expect(pos[2].value).toBeNull();
         expect(h.series).toHaveLength(2);
         expect(h.series[1].method).toBe('first');

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -871,7 +871,8 @@ describe('SignalKClient', () => {
       expect(client.connected).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/signalk/v1/api/vessels/self'),
-        {}, // buildFetchOptions() returns empty object when no token
+        // fetchJson now attaches an AbortController signal for the timeout.
+        expect.objectContaining({ signal: expect.anything() }),
       );
     });
 

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -1987,6 +1987,100 @@ describe('SignalKClient', () => {
     }, 15000);
   });
 
+  describe('getCourseStatus', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    const ok = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const err = (status: number, body: any) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      } as Response);
+
+    // Scrubbed fixtures (shape captured from a live server, no real data).
+    const notNavigating = {
+      startTime: null,
+      targetArrivalTime: null,
+      arrivalCircle: 0,
+      activeRoute: null,
+      nextPoint: null,
+      previousPoint: null,
+    };
+    const navigating = {
+      startTime: '2026-01-01T00:00:00.000Z',
+      targetArrivalTime: null,
+      arrivalCircle: 100,
+      activeRoute: null,
+      nextPoint: { type: 'Location', position: { latitude: 1, longitude: 2 } },
+      previousPoint: { type: 'Location', position: { latitude: 0, longitude: 0 } },
+    };
+    const calc = {
+      distance: 1234,
+      bearingTrue: 1.2,
+      velocityMadeGood: 2.3,
+      timeToGo: 3600,
+      estimatedTimeOfArrival: '2026-01-01T01:00:00.000Z',
+      crossTrackError: 12,
+    };
+
+    test('not navigating: navigating:false, calcValues:null, no calcValues request', async () => {
+      mockFetch.mockResolvedValueOnce(ok(notNavigating));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(true);
+      expect(r.navigating).toBe(false);
+      expect(r.course).toEqual(notNavigating);
+      expect(r.calcValues).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('navigating: merges /course and /course/calcValues', async () => {
+      mockFetch.mockResolvedValueOnce(ok(navigating));
+      mockFetch.mockResolvedValueOnce(ok(calc));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(true);
+      expect(r.navigating).toBe(true);
+      expect(r.calcValues).toEqual(calc);
+      expect(decodeURIComponent(mockFetch.mock.calls[1][0] as string)).toContain(
+        '/navigation/course/calcValues',
+      );
+    });
+
+    test('a 400 from calcValues while navigating leaves calcValues null, not an error', async () => {
+      mockFetch.mockResolvedValueOnce(ok(navigating));
+      mockFetch.mockResolvedValueOnce(
+        err(400, { statusCode: 400, message: 'No active destination!' }),
+      );
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(true);
+      expect(r.navigating).toBe(true);
+      expect(r.calcValues).toBeNull();
+      expect(r.error).toBeUndefined();
+    });
+
+    test('course API unavailable (404) => available:false, never throws', async () => {
+      mockFetch.mockResolvedValueOnce(err(404, {}));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(false);
+      expect(r.course).toBeNull();
+    });
+
+    test('network error => available:false, no throw', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const r = await client.getCourseStatus();
+      expect(r.available).toBe(false);
+    });
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -2390,6 +2390,78 @@ describe('SignalKClient', () => {
     });
   });
 
+  describe('Server Discovery Methods', () => {
+    beforeEach(() => {
+      client = new SignalKClient({
+        hostname: 'example.com',
+        port: 3000,
+        useTLS: false,
+      });
+    });
+
+    const ok = (body: any) =>
+      ({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    const err = (status: number) =>
+      ({
+        ok: false,
+        status,
+        statusText: 'err',
+        text: () => Promise.resolve(''),
+      } as Response);
+
+    // Scrubbed fixtures (shape captured from a live server, no real data).
+    const serverRoot = {
+      server: { id: 'signalk-server-node', version: '0.0.0' },
+      endpoints: { v1: { version: '1.0.0' } },
+    };
+    const featuresBody = {
+      apis: ['course', 'autopilot', 'weather', 'history'],
+      plugins: [{ id: 'example-plugin', name: 'Example', version: '1.0.0' }],
+    };
+
+    test('getServerInfo reads /signalk and parses id/version', async () => {
+      mockFetch.mockResolvedValueOnce(ok(serverRoot));
+      const r = await client.getServerInfo();
+      expect(r.available).toBe(true);
+      expect(r.name).toBe('signalk-server-node');
+      expect(r.version).toBe('0.0.0');
+      expect(r.endpoints).toEqual(serverRoot.endpoints);
+      expect(mockFetch.mock.calls[0][0] as string).toContain('/signalk');
+    });
+
+    test('getServerInfo 404 => available:false, never throws', async () => {
+      mockFetch.mockResolvedValueOnce(err(404));
+      const r = await client.getServerInfo();
+      expect(r.available).toBe(false);
+      expect(r.name).toBeNull();
+    });
+
+    test('getServerInfo network error => available:false', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const r = await client.getServerInfo();
+      expect(r.available).toBe(false);
+    });
+
+    test('getServerFeatures reads /signalk/v2/features and parses apis/plugins', async () => {
+      mockFetch.mockResolvedValueOnce(ok(featuresBody));
+      const r = await client.getServerFeatures();
+      expect(r.available).toBe(true);
+      expect(r.apis).toEqual(featuresBody.apis);
+      expect(r.plugins).toEqual(featuresBody.plugins);
+      expect(mockFetch.mock.calls[0][0] as string).toContain(
+        '/signalk/v2/features',
+      );
+    });
+
+    test('getServerFeatures 404 => available:false with empty lists', async () => {
+      mockFetch.mockResolvedValueOnce(err(404));
+      const r = await client.getServerFeatures();
+      expect(r.available).toBe(false);
+      expect(r.apis).toEqual([]);
+      expect(r.plugins).toEqual([]);
+    });
+  });
+
   describe('History Methods', () => {
     beforeEach(() => {
       client = new SignalKClient({

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -48,7 +48,7 @@ describe('SignalKClient', () => {
     // mockResolvedValueOnce queue, so an unconsumed queued response from one
     // test can never bleed into the next.
     jest.clearAllMocks();
-    mockFetch.mockReset();
+    mockFetch.mockClear();
 
     // Get the mock constructor using dynamic import
     mockSignalKClient = {
@@ -2246,11 +2246,38 @@ describe('SignalKClient', () => {
       expect(w.count).toBe(1);
       expect(w.data).toEqual(observations);
       expect(w.position).toEqual({ latitude: 12, longitude: 34 });
+      expect(w.provider).toBeNull();
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
       expect(url).toContain('/signalk/v2/api/weather/observations');
       expect(url).toContain('lat=12');
       expect(url).toContain('lon=34');
+    });
+
+    test('a partial position override (only latitude) falls back to the vessel position', async () => {
+      // One coordinate alone is unusable, so the vessel position is used.
+      mockFetch.mockResolvedValueOnce(
+        ok({ navigation: { position: { value: { latitude: 50, longitude: 60 } } } }),
+      );
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      const w = await client.getWeatherObservations({ latitude: 12 });
+      expect(w.position).toEqual({ latitude: 50, longitude: 60 });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('position (0, 0) is a valid fix (Number.isFinite, not truthy)', async () => {
+      mockFetch.mockResolvedValueOnce(ok(observations));
+      const w = await client.getWeatherObservations({
+        latitude: 0,
+        longitude: 0,
+      });
+      expect(w.available).toBe(true);
+      expect(w.position).toEqual({ latitude: 0, longitude: 0 });
+      // The explicit (0,0) override is used directly - no vessel-state probe.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+      expect(url).toContain('lat=0');
+      expect(url).toContain('lon=0');
     });
 
     test('resolves the vessel position first, then requests weather', async () => {
@@ -2291,13 +2318,14 @@ describe('SignalKClient', () => {
       expect(url).toContain('count=3');
     });
 
-    test('weather API unavailable (404) => available:false', async () => {
+    test('weather API unavailable (404) => available:false with a clear error', async () => {
       mockFetch.mockResolvedValueOnce(err(404));
       const w = await client.getWeatherObservations({
         latitude: 12,
         longitude: 34,
       });
       expect(w.available).toBe(false);
+      expect(w.error).toContain('not available');
     });
 
     test('forecast defaults to the daily endpoint', async () => {
@@ -2337,6 +2365,19 @@ describe('SignalKClient', () => {
       expect(decodeURIComponent(mockFetch.mock.calls[0][0] as string)).toContain(
         '/weather/warnings',
       );
+    });
+
+    test('warnings ignores count/date (the endpoint does not accept them)', async () => {
+      mockFetch.mockResolvedValueOnce(ok(warnings));
+      await client.getWeatherWarnings({
+        latitude: 12,
+        longitude: 34,
+        count: 5,
+        date: '2026-06-12',
+      });
+      const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+      expect(url).not.toContain('count=');
+      expect(url).not.toContain('date=');
     });
 
     test('network error => available:false, no throw', async () => {

--- a/src/signalk-client.spec.ts
+++ b/src/signalk-client.spec.ts
@@ -855,6 +855,32 @@ describe('SignalKClient', () => {
         longitude: -76.4922,
       });
     });
+
+    test('round-trips an anchor-watch path (navigation.anchor.currentRadius)', async () => {
+      // Anchor watch needs no new client method - it is just getPathValue on the
+      // navigation.anchor.* paths. This locks that round trip (request -> value).
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            value: 23.4,
+            meta: { units: 'm', description: 'Current distance from anchor' },
+            timestamp: '2026-06-12T00:00:00.000Z',
+            $source: 'anchoralarm',
+          }),
+      } as Response);
+
+      const result = await client.getPathValue(
+        'navigation.anchor.currentRadius',
+      );
+
+      expect(result.path).toBe('navigation.anchor.currentRadius');
+      expect(result.data.value).toBe(23.4);
+      expect(result.data.meta.units).toBe('m');
+      expect(decodeURIComponent(mockFetch.mock.calls[0][0] as string)).toContain(
+        'navigation/anchor/currentRadius',
+      );
+    });
   });
 
   describe('Connection Management', () => {

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -143,6 +143,34 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * Build a SignalK v2 History API URL.
+   *
+   * The History API lives at /signalk/v2/api/history/<endpoint> - a different
+   * base path from buildRestApiUrl (/signalk/v1/api/vessels/...). Query values
+   * that are undefined or empty are dropped. Reserved characters in the path
+   * expression (':' and ',') are percent-encoded by URLSearchParams and decoded
+   * by the server before it splits them.
+   *
+   * @param endpoint - 'values', 'contexts', or 'paths'
+   * @param params - query parameters; undefined/empty values are omitted
+   * @returns Complete History API URL
+   */
+  buildHistoryApiUrl(
+    endpoint: 'values' | 'contexts' | 'paths',
+    params: Record<string, string | number | undefined> = {},
+  ): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        query.set(key, String(value));
+      }
+    }
+    const queryString = query.toString();
+    const suffix = queryString ? `?${queryString}` : '';
+    return `${this.buildHttpUrl()}/signalk/v2/api/history/${endpoint}${suffix}`;
+  }
+
+  /**
    * Build fetch options with authentication headers if token is configured
    * @returns RequestInit object with authorization header if token exists
    */

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -191,6 +191,49 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * fetch() wrapped with an AbortController timeout and one bounded retry, so a
+   * hung or flaky SignalK server fails fast and legibly instead of stalling a
+   * tool call. Auth headers (buildFetchOptions) are applied automatically.
+   * Returns the Response; callers handle response.ok / .json() as before.
+   */
+  private async fetchJson(
+    url: string,
+    init: RequestInit = {},
+    opts: { timeoutMs?: number; retries?: number } = {},
+  ): Promise<Response> {
+    const timeoutMs = opts.timeoutMs ?? 10000;
+    const retries = opts.retries ?? 1;
+    const base = this.buildFetchOptions();
+
+    let lastError: any;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        return await fetch(url, {
+          ...base,
+          ...init,
+          headers: { ...(base.headers as any), ...(init.headers as any) },
+          signal: controller.signal,
+        });
+      } catch (error: any) {
+        const aborted = error?.name === 'AbortError';
+        lastError = aborted
+          ? new Error(`Request timed out after ${timeoutMs}ms`)
+          : error;
+        // Retry once on a timeout only; a hard network/parse error fails fast.
+        if (!aborted || attempt >= retries) {
+          throw lastError;
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    // Unreachable (the loop either returns or throws), satisfies the type checker.
+    throw lastError;
+  }
+
+  /**
    * Sets up WebSocket event handlers for connection, disconnection, errors, and delta messages
    *
    * Event handlers:
@@ -254,7 +297,7 @@ export class SignalKClient extends EventEmitter {
     // Test HTTP connectivity
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -320,7 +363,7 @@ export class SignalKClient extends EventEmitter {
   private async fetchInitialVesselState(): Promise<void> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -626,7 +669,7 @@ export class SignalKClient extends EventEmitter {
   async getVesselState(): Promise<VesselState> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -839,7 +882,7 @@ export class SignalKClient extends EventEmitter {
 
       // Fetch all vessels from the API
       const apiUrl = `${this.buildHttpUrl()}/signalk/v1/api/vessels`;
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1034,7 +1077,7 @@ export class SignalKClient extends EventEmitter {
   async getActiveAlarms(): Promise<ActiveAlarmsResponse> {
     try {
       const apiUrl = this.buildRestApiUrl('self');
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1133,7 +1176,7 @@ export class SignalKClient extends EventEmitter {
       // Use helper method to build REST API URL
       const apiUrl = this.buildRestApiUrl('self');
 
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -1236,7 +1279,7 @@ export class SignalKClient extends EventEmitter {
       // Use helper method to build REST API URL for the specific path
       const apiUrl = this.buildRestApiUrl('self', path);
 
-      const response = await fetch(apiUrl, this.buildFetchOptions());
+      const response = await this.fetchJson(apiUrl);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -1335,7 +1378,7 @@ export class SignalKClient extends EventEmitter {
     });
 
     try {
-      const response = await fetch(url, this.buildFetchOptions());
+      const response = await this.fetchJson(url);
       if (!response.ok) {
         const detail = await response.text().catch(() => '');
         const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
@@ -1539,7 +1582,7 @@ export class SignalKClient extends EventEmitter {
     });
 
     try {
-      const response = await fetch(url, this.buildFetchOptions());
+      const response = await this.fetchJson(url);
       if (!response.ok) {
         const detail = await response.text().catch(() => '');
         const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -889,7 +889,7 @@ export class SignalKClient extends EventEmitter {
    * //     "timestamp": "2023-06-22T10:30:15Z",
    * //     "values": [{
    * //       "path": "navigation.position",
-   * //       "value": {"latitude": 37.8199, "longitude": -122.4783}
+   * //       "value": {"latitude": 38.9784, "longitude": -76.4922}
    * //     }]
    * //   }]
    * // }
@@ -945,7 +945,7 @@ export class SignalKClient extends EventEmitter {
    * // AIS targets are updated automatically from delta messages:
    * // Context: "vessels.urn:mrn:imo:mmsi:123456789"
    * // Path: "navigation.position"
-   * // Value: {"latitude": 37.8200, "longitude": -122.4800}
+   * // Value: {"latitude": 38.9785, "longitude": -76.4923}
    *
    * const targets = client.getAISTargets();
    * console.log('Nearby vessels:', targets.targets.length);
@@ -1054,7 +1054,7 @@ export class SignalKClient extends EventEmitter {
    * //       "source": "vessel-identity"
    * //     },
    * //     "navigation.position": {
-   * //       "value": {"latitude": 37.8199, "longitude": -122.4783},
+   * //       "value": {"latitude": 38.9784, "longitude": -76.4922},
    * //       "timestamp": "2023-06-22T10:30:15.000Z",
    * //       "source": {"label": "GPS1", "type": "NMEA0183"}
    * //     },
@@ -1237,7 +1237,7 @@ export class SignalKClient extends EventEmitter {
    * //       "mmsi": "123456789",
    * //       "distanceMeters": 1852.5,
    * //       "navigation.position": {
-   * //         "value": {"latitude": 37.8200, "longitude": -122.4800},
+   * //         "value": {"latitude": 38.9785, "longitude": -76.4923},
    * //         "timestamp": "2023-06-22T10:29:45.000Z"
    * //       },
    * //       "lastUpdate": "2023-06-22T10:29:45.000Z"
@@ -1662,8 +1662,8 @@ export class SignalKClient extends EventEmitter {
    * //   "timestamp": "2023-06-22T10:30:15.123Z",
    * //   "data": {
    * //     "value": {
-   * //       "latitude": 37.8199,
-   * //       "longitude": -122.4783
+   * //       "latitude": 38.9784,
+   * //       "longitude": -76.4922
    * //     },
    * //     "timestamp": "2023-06-22T10:30:15.000Z",
    * //     "source": {

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -19,6 +19,7 @@ import type {
   HistoryPathsResponse,
   HistoryContextsResponse,
   CourseStatusResponse,
+  AutopilotStatusResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -260,6 +261,29 @@ export class SignalKClient extends EventEmitter {
       course,
       calcValues,
       timestamp: now(),
+    };
+  }
+
+  /**
+   * Autopilot status (read-only): engaged / state / mode / target plus the
+   * available states, modes and actions. Reads the default device, or the given
+   * pilotId. target is converted from SignalK radians to degrees. Never throws.
+   */
+  async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
+    // STUB - real implementation follows in the next commit.
+    void pilotId;
+    return {
+      available: false,
+      connected: this.connected,
+      pilotId: null,
+      pilotIds: [],
+      engaged: null,
+      state: null,
+      mode: null,
+      targetDegrees: null,
+      targetRadians: null,
+      options: null,
+      timestamp: new Date().toISOString(),
     };
   }
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -436,30 +436,133 @@ export class SignalKClient extends EventEmitter {
   }
 
   /**
+   * Shared worker for the weather reads. Resolves the vessel position (the
+   * weather API requires lat/lon on every endpoint), and only then fetches the
+   * given endpoint. With no position fix the weather request is never sent.
+   * Never throws.
+   *
+   * @param kind - 'observations' | 'forecast' | 'warnings'
+   * @param endpoint - URL path under .../weather (e.g. 'forecasts/daily')
+   * @param forecastType - 'daily' | 'point' for forecasts, else null
+   * @param options - position override / provider / count / date
+   * @param seriesParams - whether to send count/date (not accepted by warnings)
+   */
+  private async fetchWeather(
+    kind: string,
+    endpoint: string,
+    forecastType: string | null,
+    options: WeatherQueryOptions | undefined,
+    seriesParams: boolean,
+  ): Promise<WeatherResponse> {
+    const now = () => new Date().toISOString();
+    const opts = options || {};
+
+    // 1) Resolve the query position: an explicit override, else the vessel's
+    //    current position. No fix => return without firing the weather request.
+    let position: { latitude: number; longitude: number } | null = null;
+    if (Number.isFinite(opts.latitude) && Number.isFinite(opts.longitude)) {
+      position = {
+        latitude: opts.latitude as number,
+        longitude: opts.longitude as number,
+      };
+    } else {
+      try {
+        const selfData = await this.getVesselState();
+        const value = selfData.data['navigation.position']?.value as
+          | { latitude?: number; longitude?: number }
+          | undefined;
+        if (
+          value &&
+          Number.isFinite(value.latitude) &&
+          Number.isFinite(value.longitude)
+        ) {
+          position = {
+            latitude: Number(value.latitude),
+            longitude: Number(value.longitude),
+          };
+        }
+      } catch {
+        // Leave position null; handled as "no fix" below.
+      }
+    }
+
+    if (!position) {
+      return this.weatherUnavailable(kind, forecastType, 'no vessel position');
+    }
+
+    // 2) Build the request (lat/lon required; provider/count/date optional).
+    const params: Record<string, string | number | undefined> = {
+      lat: position.latitude,
+      lon: position.longitude,
+      provider: opts.provider,
+    };
+    if (seriesParams) {
+      params.count = opts.count;
+      params.date = opts.date;
+    }
+
+    // 3) Fetch and shape the response.
+    try {
+      const response = await this.fetchJson(
+        this.buildWeatherApiUrl(endpoint, params),
+      );
+      if (!response.ok) {
+        const s = response.status;
+        const error =
+          s === 404 || s === 501
+            ? `Weather API not available on this SignalK server (HTTP ${s})`
+            : s === 401 || s === 403
+              ? `Weather API requires authentication - set SIGNALK_TOKEN (HTTP ${s})`
+              : `Weather request failed (HTTP ${s})`;
+        return this.weatherUnavailable(kind, forecastType, undefined, {
+          position,
+          provider: opts.provider ?? null,
+          error,
+        });
+      }
+      const body = await response.json();
+      const data: any[] = Array.isArray(body) ? body : [];
+      return {
+        available: true,
+        connected: this.connected,
+        kind,
+        forecastType,
+        position,
+        provider: opts.provider ?? null,
+        data,
+        count: data.length,
+        timestamp: now(),
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch weather via HTTP:', error.message);
+      return this.weatherUnavailable(kind, forecastType, undefined, {
+        position,
+        provider: opts.provider ?? null,
+        error: `Weather request failed: ${error?.message || String(error)}`,
+      });
+    }
+  }
+
+  /**
    * Current weather observations for the vessel's position (read-only).
    * @param options - optional position override / provider / count / date
    */
   async getWeatherObservations(
     options?: WeatherQueryOptions,
   ): Promise<WeatherResponse> {
-    // STUB - real implementation follows in the next commit.
-    await Promise.resolve();
-    void options;
-    return this.weatherUnavailable('observations', null, 'not implemented');
+    return this.fetchWeather('observations', 'observations', null, options, true);
   }
 
   /**
    * Weather forecast for the vessel's position (read-only). type selects the
-   * 'daily' (per-day) or 'point' (per time-point) forecast.
+   * 'daily' (per-day) or 'point' (per time-point) forecast; defaults to 'daily'.
    * @param options - type plus optional position / provider / count / date
    */
   async getWeatherForecast(
     options?: WeatherQueryOptions,
   ): Promise<WeatherResponse> {
-    // STUB - real implementation follows in the next commit.
-    await Promise.resolve();
-    void options;
-    return this.weatherUnavailable('forecast', 'daily', 'not implemented');
+    const type = options?.type === 'point' ? 'point' : 'daily';
+    return this.fetchWeather('forecast', `forecasts/${type}`, type, options, true);
   }
 
   /**
@@ -469,10 +572,7 @@ export class SignalKClient extends EventEmitter {
   async getWeatherWarnings(
     options?: WeatherQueryOptions,
   ): Promise<WeatherResponse> {
-    // STUB - real implementation follows in the next commit.
-    await Promise.resolve();
-    void options;
-    return this.weatherUnavailable('warnings', null, 'not implemented');
+    return this.fetchWeather('warnings', 'warnings', null, options, false);
   }
 
   /**

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -20,6 +20,8 @@ import type {
   HistoryContextsResponse,
   CourseStatusResponse,
   AutopilotStatusResponse,
+  WeatherQueryOptions,
+  WeatherResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -185,6 +187,27 @@ export class SignalKClient extends EventEmitter {
   buildCourseApiUrl(endpoint: string = ''): string {
     const suffix = endpoint ? `/${endpoint}` : '';
     return `${this.buildHttpUrl()}/signalk/v2/api/vessels/self/navigation/course${suffix}`;
+  }
+
+  /**
+   * Build a SignalK v2 weather API URL with a query string. Undefined / empty
+   * params are dropped (lat/lon are required by the server on every endpoint).
+   * @param endpoint - 'observations', 'forecasts/daily', 'forecasts/point', 'warnings'
+   * @param params - lat, lon (required) plus optional provider / count / date
+   */
+  buildWeatherApiUrl(
+    endpoint: string,
+    params: Record<string, string | number | undefined> = {},
+  ): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        query.set(key, String(value));
+      }
+    }
+    const queryString = query.toString();
+    const suffix = queryString ? `?${queryString}` : '';
+    return `${this.buildHttpUrl()}/signalk/v2/api/weather/${endpoint}${suffix}`;
   }
 
   /**
@@ -385,6 +408,71 @@ export class SignalKClient extends EventEmitter {
         error: `Autopilot status request failed: ${error?.message || String(error)}`,
       });
     }
+  }
+
+  /**
+   * Build a degraded weather response (available:false). Used by the
+   * not-implemented stub and by the graceful-degradation paths.
+   */
+  private weatherUnavailable(
+    kind: string,
+    forecastType: string | null,
+    reason?: string,
+    extra: Partial<WeatherResponse> = {},
+  ): WeatherResponse {
+    return {
+      available: false,
+      connected: this.connected,
+      kind,
+      forecastType,
+      position: null,
+      provider: null,
+      data: [],
+      count: 0,
+      timestamp: new Date().toISOString(),
+      ...(reason ? { reason } : {}),
+      ...extra,
+    };
+  }
+
+  /**
+   * Current weather observations for the vessel's position (read-only).
+   * @param options - optional position override / provider / count / date
+   */
+  async getWeatherObservations(
+    options?: WeatherQueryOptions,
+  ): Promise<WeatherResponse> {
+    // STUB - real implementation follows in the next commit.
+    await Promise.resolve();
+    void options;
+    return this.weatherUnavailable('observations', null, 'not implemented');
+  }
+
+  /**
+   * Weather forecast for the vessel's position (read-only). type selects the
+   * 'daily' (per-day) or 'point' (per time-point) forecast.
+   * @param options - type plus optional position / provider / count / date
+   */
+  async getWeatherForecast(
+    options?: WeatherQueryOptions,
+  ): Promise<WeatherResponse> {
+    // STUB - real implementation follows in the next commit.
+    await Promise.resolve();
+    void options;
+    return this.weatherUnavailable('forecast', 'daily', 'not implemented');
+  }
+
+  /**
+   * Active weather warnings for the vessel's position (read-only).
+   * @param options - optional position override / provider
+   */
+  async getWeatherWarnings(
+    options?: WeatherQueryOptions,
+  ): Promise<WeatherResponse> {
+    // STUB - real implementation follows in the next commit.
+    await Promise.resolve();
+    void options;
+    return this.weatherUnavailable('warnings', null, 'not implemented');
   }
 
   /**

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -194,14 +194,72 @@ export class SignalKClient extends EventEmitter {
    * calcValues:null when not navigating. Never throws.
    */
   async getCourseStatus(): Promise<CourseStatusResponse> {
-    // STUB - real implementation follows in the next commit.
+    const now = () => new Date().toISOString();
+    let course: any = null;
+
+    // 1) Read the course root - the source of truth for whether a destination
+    //    is set. It returns 200 with null fields when not navigating.
+    try {
+      const response = await this.fetchJson(this.buildCourseApiUrl());
+      if (!response.ok) {
+        const s = response.status;
+        const error =
+          s === 404 || s === 501
+            ? `Course API not available on this SignalK server (HTTP ${s})`
+            : s === 401 || s === 403
+              ? `Course API requires authentication - set SIGNALK_TOKEN (HTTP ${s})`
+              : `Course request failed (HTTP ${s})`;
+        return {
+          available: false,
+          connected: this.connected,
+          navigating: false,
+          course: null,
+          calcValues: null,
+          timestamp: now(),
+          error,
+        };
+      }
+      course = await response.json();
+    } catch (error: any) {
+      console.error('Failed to fetch course status via HTTP:', error.message);
+      return {
+        available: false,
+        connected: this.connected,
+        navigating: false,
+        course: null,
+        calcValues: null,
+        timestamp: now(),
+        error: `Course request failed: ${error?.message || String(error)}`,
+      };
+    }
+
+    const navigating = !!(course && (course.activeRoute || course.nextPoint));
+
+    // 2) Only fetch calc values when navigating; /calcValues returns HTTP 400
+    //    ("No active destination!") otherwise, which is a normal state, not an
+    //    error - so we never even ask for it when there is no destination.
+    let calcValues: any = null;
+    if (navigating) {
+      try {
+        const response = await this.fetchJson(
+          this.buildCourseApiUrl('calcValues'),
+        );
+        if (response.ok) {
+          calcValues = await response.json();
+        }
+        // A non-ok response (e.g. a 400 race) just leaves calcValues null.
+      } catch {
+        // Leave calcValues null; the course root already answered the question.
+      }
+    }
+
     return {
-      available: false,
+      available: true,
       connected: this.connected,
-      navigating: false,
-      course: null,
-      calcValues: null,
-      timestamp: new Date().toISOString(),
+      navigating,
+      course,
+      calcValues,
+      timestamp: now(),
     };
   }
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -22,6 +22,8 @@ import type {
   AutopilotStatusResponse,
   WeatherQueryOptions,
   WeatherResponse,
+  ServerInfoResponse,
+  ServerFeaturesResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -573,6 +575,39 @@ export class SignalKClient extends EventEmitter {
     options?: WeatherQueryOptions,
   ): Promise<WeatherResponse> {
     return this.fetchWeather('warnings', 'warnings', null, options, false);
+  }
+
+  /**
+   * Server identity and available endpoints (GET /signalk). Read-only; needs no
+   * vessel position. Never throws.
+   */
+  async getServerInfo(): Promise<ServerInfoResponse> {
+    // STUB - real implementation follows in the next commit.
+    await Promise.resolve();
+    return {
+      available: false,
+      connected: this.connected,
+      name: null,
+      version: null,
+      endpoints: null,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * The APIs and plugins the server has enabled (GET /signalk/v2/features).
+   * Read-only; needs no vessel position. Never throws.
+   */
+  async getServerFeatures(): Promise<ServerFeaturesResponse> {
+    // STUB - real implementation follows in the next commit.
+    await Promise.resolve();
+    return {
+      available: false,
+      connected: this.connected,
+      apis: [],
+      plugins: [],
+      timestamp: new Date().toISOString(),
+    };
   }
 
   /**

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -579,19 +579,45 @@ export class SignalKClient extends EventEmitter {
 
   /**
    * Server identity and available endpoints (GET /signalk). Read-only; needs no
-   * vessel position. Never throws.
+   * vessel position. A short timeout keeps callers responsive when the server is
+   * unreachable. Never throws.
    */
   async getServerInfo(): Promise<ServerInfoResponse> {
-    // STUB - real implementation follows in the next commit.
-    await Promise.resolve();
-    return {
+    const now = () => new Date().toISOString();
+    const degraded = (error?: string): ServerInfoResponse => ({
       available: false,
       connected: this.connected,
       name: null,
       version: null,
       endpoints: null,
-      timestamp: new Date().toISOString(),
-    };
+      timestamp: now(),
+      ...(error ? { error } : {}),
+    });
+
+    try {
+      const response = await this.fetchJson(
+        `${this.buildHttpUrl()}/signalk`,
+        {},
+        { timeoutMs: 5000 },
+      );
+      if (!response.ok) {
+        return degraded(`Server discovery failed (HTTP ${response.status})`);
+      }
+      const body: any = await response.json();
+      return {
+        available: true,
+        connected: this.connected,
+        name: body?.server?.id ?? null,
+        version: body?.server?.version ?? null,
+        endpoints: body?.endpoints ?? null,
+        timestamp: now(),
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch server info via HTTP:', error.message);
+      return degraded(
+        `Server discovery request failed: ${error?.message || String(error)}`,
+      );
+    }
   }
 
   /**
@@ -599,15 +625,39 @@ export class SignalKClient extends EventEmitter {
    * Read-only; needs no vessel position. Never throws.
    */
   async getServerFeatures(): Promise<ServerFeaturesResponse> {
-    // STUB - real implementation follows in the next commit.
-    await Promise.resolve();
-    return {
+    const now = () => new Date().toISOString();
+    const degraded = (error?: string): ServerFeaturesResponse => ({
       available: false,
       connected: this.connected,
       apis: [],
       plugins: [],
-      timestamp: new Date().toISOString(),
-    };
+      timestamp: now(),
+      ...(error ? { error } : {}),
+    });
+
+    try {
+      const response = await this.fetchJson(
+        `${this.buildHttpUrl()}/signalk/v2/features`,
+        {},
+        { timeoutMs: 5000 },
+      );
+      if (!response.ok) {
+        return degraded(`Features request failed (HTTP ${response.status})`);
+      }
+      const body: any = await response.json();
+      return {
+        available: true,
+        connected: this.connected,
+        apis: Array.isArray(body?.apis) ? body.apis : [],
+        plugins: Array.isArray(body?.plugins) ? body.plugins : [],
+        timestamp: now(),
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch server features via HTTP:', error.message);
+      return degraded(
+        `Features request failed: ${error?.message || String(error)}`,
+      );
+    }
   }
 
   /**

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -18,6 +18,7 @@ import type {
   HistoryDataPoint,
   HistoryPathsResponse,
   HistoryContextsResponse,
+  CourseStatusResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -174,6 +175,34 @@ export class SignalKClient extends EventEmitter {
     const queryString = query.toString();
     const suffix = queryString ? `?${queryString}` : '';
     return `${this.buildHttpUrl()}/signalk/v2/api/history/${endpoint}${suffix}`;
+  }
+
+  /**
+   * Build a SignalK v2 course API URL (under .../navigation/course).
+   * @param endpoint - '' for the course root, or 'calcValues'
+   */
+  buildCourseApiUrl(endpoint: string = ''): string {
+    const suffix = endpoint ? `/${endpoint}` : '';
+    return `${this.buildHttpUrl()}/signalk/v2/api/vessels/self/navigation/course${suffix}`;
+  }
+
+  /**
+   * Current navigation course: active route / destination plus calculated values
+   * (cross-track error, bearing, ETA, VMG, time-to-go). Reads /navigation/course
+   * (the source of truth for whether a destination is set) and, only when one is
+   * active, /navigation/course/calcValues. Returns navigating:false with
+   * calcValues:null when not navigating. Never throws.
+   */
+  async getCourseStatus(): Promise<CourseStatusResponse> {
+    // STUB - real implementation follows in the next commit.
+    return {
+      available: false,
+      connected: this.connected,
+      navigating: false,
+      course: null,
+      calcValues: null,
+      timestamp: new Date().toISOString(),
+    };
   }
 
   /**

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -1583,12 +1583,21 @@ export class SignalKClient extends EventEmitter {
           if (currentPath.startsWith('notifications.') && value && typeof value === 'object' && 'value' in value) {
             const notifValue = (value as any).value;
             if (notifValue && notifValue.state) {
-              alarms.push({
+              const alarm: ActiveAlarm = {
                 path: currentPath,
                 state: notifValue.state,
                 message: notifValue.message || '',
                 timestamp: (value as any).timestamp || new Date().toISOString(),
-              });
+              };
+              // Optional enrichment - only added when the server provides it, so
+              // the existing path/state/message/timestamp contract is unchanged.
+              if (Array.isArray(notifValue.method)) {
+                alarm.method = notifValue.method;
+              }
+              if (notifValue.status && typeof notifValue.status === 'object') {
+                alarm.status = notifValue.status;
+              }
+              alarms.push(alarm);
             }
           } else if (value && typeof value === 'object' && !Array.isArray(value)) {
             extractNotifications(value, currentPath);

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -12,6 +12,12 @@ import type {
   ConnectionStatus,
   AvailablePathsResponse,
   PathValueResponse,
+  HistoryQueryOptions,
+  HistoryResponse,
+  HistorySeries,
+  HistoryDataPoint,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from './types/index.js';
 
 export class SignalKClient extends EventEmitter {
@@ -1257,6 +1263,295 @@ export class SignalKClient extends EventEmitter {
         timestamp: new Date().toISOString(),
         error: `HTTP fetch failed: ${error.message}, using cached value`,
       };
+    }
+  }
+
+  /**
+   * Query aggregated historical time-series for one or more SignalK paths.
+   *
+   * Hits the SignalK v2 History API (/signalk/v2/api/history/values) and folds
+   * its tabular response into per-path series. Unlike getPathValue there is NO
+   * cache fallback - history has no live cache. The method never throws; it
+   * always returns a HistoryResponse whose `available` flag tells callers
+   * whether a history provider answered.
+   *
+   * @param options - paths plus a time window (from/to or duration), resolution
+   *                  in SECONDS, optional default aggregate, and context
+   * @returns HistoryResponse with `series` (one entry per response column) and a
+   *          convenience `values` map keyed by path
+   */
+  async getHistory(options: HistoryQueryOptions): Promise<HistoryResponse> {
+    // Normalize and coerce paths to strings up front so stray non-string input
+    // from untyped isolate code can never throw before the request is built.
+    const rawPaths = Array.isArray(options?.paths) ? options.paths : [options?.paths];
+    const requestedPaths = rawPaths
+      .filter((p) => p !== undefined && p !== null)
+      .map((p) => String(p));
+
+    const empty = (available: boolean, error?: string): HistoryResponse => ({
+      available,
+      connected: this.connected,
+      resolution: options?.resolution,
+      requestedPaths,
+      series: [],
+      values: {},
+      missingPaths: requestedPaths.map((p) => p.split(':')[0]),
+      timestamp: new Date().toISOString(),
+      ...(error ? { error } : {}),
+    });
+
+    if (requestedPaths.length === 0) {
+      return empty(true, 'Invalid history query: at least one path is required');
+    }
+
+    // Validate the time window. The server requires at least one of `from` or
+    // `duration`; a missing/`to`-only window or a non-ISO time is a client
+    // error, reported distinctly from a missing provider and without a request.
+    const from = this.normalizeIso(options.from);
+    if (options.from !== undefined && from === undefined) {
+      return empty(true, 'Invalid history query: "from" must be an ISO-8601 time (e.g. 2026-06-11T06:00:00Z)');
+    }
+    const to = this.normalizeIso(options.to);
+    if (options.to !== undefined && to === undefined) {
+      return empty(true, 'Invalid history query: "to" must be an ISO-8601 time (e.g. 2026-06-11T12:00:00Z)');
+    }
+    const duration = options.duration !== undefined ? String(options.duration) : undefined;
+    if (from === undefined && duration === undefined) {
+      return empty(true, 'Invalid history query: provide "from" or "duration"');
+    }
+
+    const pathsParam = requestedPaths
+      .map((p) => this.composeHistoryPath(p, options.aggregate))
+      .join(',');
+
+    const url = this.buildHistoryApiUrl('values', {
+      context: options.context ?? this.context,
+      paths: pathsParam,
+      from,
+      to,
+      duration,
+      resolution: options.resolution,
+      provider: options.provider,
+    });
+
+    try {
+      const response = await fetch(url, this.buildFetchOptions());
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
+        return empty(available, error);
+      }
+      const body: any = await response.json();
+      return this.transformHistoryValues(body, requestedPaths, options.resolution);
+    } catch (error: any) {
+      console.error('Failed to fetch history values via HTTP:', error.message);
+      const { available, error: message } = this.classifyHistoryFailure(undefined, error?.message || String(error));
+      return empty(available, message);
+    }
+  }
+
+  /**
+   * List SignalK paths that have historical data in a time window.
+   * @returns HistoryPathsResponse; `available:false` means no history provider
+   */
+  async listHistoryPaths(
+    options: { from?: string; to?: string; duration?: string | number; context?: string } = {},
+  ): Promise<HistoryPathsResponse> {
+    const r = await this.fetchHistoryStringList('paths', options);
+    return {
+      available: r.available,
+      connected: this.connected,
+      count: r.items.length,
+      paths: r.items,
+      timestamp: new Date().toISOString(),
+      ...(r.error ? { error: r.error } : {}),
+    };
+  }
+
+  /**
+   * List vessel contexts that have historical data in a time window.
+   * @returns HistoryContextsResponse; `available:false` means no history provider
+   */
+  async listHistoryContexts(
+    options: { from?: string; to?: string; duration?: string | number } = {},
+  ): Promise<HistoryContextsResponse> {
+    const r = await this.fetchHistoryStringList('contexts', options);
+    return {
+      available: r.available,
+      connected: this.connected,
+      count: r.items.length,
+      contexts: r.items,
+      timestamp: new Date().toISOString(),
+      ...(r.error ? { error: r.error } : {}),
+    };
+  }
+
+  /**
+   * Build one entry of the comma-separated `paths` param. A path may already
+   * carry an inline aggregation method (path:method[:param]); if so it is left
+   * untouched. Otherwise an optional default `aggregate` is applied - but never
+   * to navigation.position (the server aggregates positions with "first").
+   */
+  private composeHistoryPath(pathExpr: string, aggregate?: string): string {
+    const hasInlineMethod = pathExpr.split(':').length >= 2;
+    if (hasInlineMethod || !aggregate) {
+      return pathExpr;
+    }
+    if (pathExpr === 'navigation.position') {
+      return pathExpr;
+    }
+    return `${pathExpr}:${aggregate}`;
+  }
+
+  /**
+   * Coerce a time input to an ISO-8601 string. Accepts a Date or epoch-ms
+   * number; passes a valid ISO-ish string through; returns undefined for input
+   * that cannot be a real instant (so the caller can report a clear error).
+   */
+  private normalizeIso(value: unknown): string | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      return isNaN(value.getTime()) ? undefined : value.toISOString();
+    }
+    if (typeof value === 'number') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? undefined : d.toISOString();
+    }
+    if (typeof value === 'string') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? undefined : value;
+    }
+    return undefined;
+  }
+
+  /**
+   * Map an HTTP status (or network error) to history availability + message.
+   * 404/501 or a network error means no provider is installed (available:false).
+   * 400/422 means the provider exists but the request was bad (available:true).
+   * 401/403 means the provider exists but needs auth (available:true).
+   */
+  private classifyHistoryFailure(
+    status: number | undefined,
+    detail: string,
+  ): { available: boolean; error: string } {
+    const suffix = detail ? `: ${detail}` : '';
+    if (status === 404 || status === 501) {
+      return {
+        available: false,
+        error: `History API not available - no history provider installed on the SignalK server (HTTP ${status})`,
+      };
+    }
+    if (status === 400 || status === 422) {
+      return { available: true, error: `Invalid history query (HTTP ${status})${suffix}` };
+    }
+    if (status === 401 || status === 403) {
+      return {
+        available: true,
+        error: `History API requires authentication - set SIGNALK_TOKEN (HTTP ${status})`,
+      };
+    }
+    return {
+      available: false,
+      error: `History API request failed${status ? ` (HTTP ${status})` : ''}${suffix}`,
+    };
+  }
+
+  /**
+   * Convert the server's tabular history response into per-path series. The
+   * response `values` array is authoritative: column i+1 of each data row maps
+   * to values[i].path. We iterate the response columns (never the request) so
+   * reordered, duplicate, or absent paths are handled correctly.
+   */
+  private transformHistoryValues(
+    body: any,
+    requestedPaths: string[],
+    resolution?: number,
+  ): HistoryResponse {
+    const columns: Array<{ path: string; method: string }> = Array.isArray(body?.values)
+      ? body.values
+      : [];
+    const rows: any[][] = Array.isArray(body?.data) ? body.data : [];
+
+    const series: HistorySeries[] = columns.map((col, i) => ({
+      path: col?.path,
+      method: col?.method,
+      points: rows.map(
+        (row): HistoryDataPoint => ({
+          timestamp: row?.[0],
+          value: row?.[i + 1] ?? null,
+        }),
+      ),
+    }));
+
+    // Convenience map keyed by path; the last method wins on duplicate paths
+    // (use `series` to keep every column).
+    const values: Record<string, HistoryDataPoint[]> = {};
+    for (const s of series) {
+      values[s.path] = s.points;
+    }
+
+    const returnedPaths = new Set(columns.map((c) => c?.path));
+    const missingPaths = requestedPaths
+      .map((p) => p.split(':')[0])
+      .filter((p) => !returnedPaths.has(p));
+
+    return {
+      available: true,
+      connected: this.connected,
+      context: body?.context,
+      range: body?.range,
+      resolution,
+      requestedPaths,
+      series,
+      values,
+      missingPaths,
+      rowCount: rows.length,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Shared fetch + degradation handling for the history list endpoints
+   * (paths/contexts), which both return a JSON array of strings.
+   */
+  private async fetchHistoryStringList(
+    endpoint: 'paths' | 'contexts',
+    options: { from?: string; to?: string; duration?: string | number; context?: string },
+  ): Promise<{ available: boolean; items: string[]; error?: string }> {
+    const from = this.normalizeIso(options.from);
+    const to = this.normalizeIso(options.to);
+    // The list endpoints scope to a time window; default to the last 24h when
+    // the caller gives neither `from` nor `duration` so the result is not empty.
+    const duration =
+      options.duration !== undefined
+        ? String(options.duration)
+        : from === undefined
+          ? 'PT24H'
+          : undefined;
+
+    const url = this.buildHistoryApiUrl(endpoint, {
+      context: options.context,
+      from,
+      to,
+      duration,
+    });
+
+    try {
+      const response = await fetch(url, this.buildFetchOptions());
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const { available, error } = this.classifyHistoryFailure(response.status, detail.slice(0, 200));
+        return { available, items: [], error };
+      }
+      const body: any = await response.json();
+      const items: string[] = Array.isArray(body) ? body : [];
+      return { available: true, items };
+    } catch (error: any) {
+      console.error(`Failed to fetch history ${endpoint} via HTTP:`, error.message);
+      const { available, error: message } = this.classifyHistoryFailure(undefined, error?.message || String(error));
+      return { available, items: [], error: message };
     }
   }
 

--- a/src/signalk-client.ts
+++ b/src/signalk-client.ts
@@ -270,10 +270,13 @@ export class SignalKClient extends EventEmitter {
    * pilotId. target is converted from SignalK radians to degrees. Never throws.
    */
   async getAutopilotStatus(pilotId?: string): Promise<AutopilotStatusResponse> {
-    // STUB - real implementation follows in the next commit.
-    void pilotId;
-    return {
-      available: false,
+    const now = () => new Date().toISOString();
+    const base = `${this.buildHttpUrl()}/signalk/v2/api/vessels/self/autopilots`;
+    const empty = (
+      available: boolean,
+      extra: Partial<AutopilotStatusResponse> = {},
+    ): AutopilotStatusResponse => ({
+      available,
       connected: this.connected,
       pilotId: null,
       pilotIds: [],
@@ -283,8 +286,105 @@ export class SignalKClient extends EventEmitter {
       targetDegrees: null,
       targetRadians: null,
       options: null,
-      timestamp: new Date().toISOString(),
-    };
+      timestamp: now(),
+      ...extra,
+    });
+
+    // 1) List autopilot devices: a keyed object { id: { provider, isDefault } }.
+    let devices: Record<string, any> = {};
+    try {
+      const response = await this.fetchJson(base);
+      if (!response.ok) {
+        const s = response.status;
+        const error =
+          s === 404 || s === 501
+            ? `Autopilot API not available on this SignalK server (HTTP ${s})`
+            : s === 401 || s === 403
+              ? `Autopilot API requires authentication - set SIGNALK_TOKEN (HTTP ${s})`
+              : `Autopilot request failed (HTTP ${s})`;
+        return empty(false, { error });
+      }
+      devices = (await response.json()) || {};
+    } catch (error: any) {
+      console.error('Failed to fetch autopilots via HTTP:', error.message);
+      return empty(false, {
+        error: `Autopilot request failed: ${error?.message || String(error)}`,
+      });
+    }
+
+    const pilotIds = Object.keys(devices);
+    if (pilotIds.length === 0) {
+      return empty(true);
+    }
+
+    // 2) Resolve which device to read: explicit pilotId, else isDefault, else
+    //    the documented default provider, else the first device.
+    let chosen: string;
+    if (pilotId) {
+      chosen = pilotId;
+    } else {
+      const byFlag = pilotIds.find((id) => devices[id]?.isDefault);
+      if (byFlag) {
+        chosen = byFlag;
+      } else {
+        let viaDefault: string | undefined;
+        try {
+          const res = await this.fetchJson(`${base}/_providers/_default`);
+          if (res.ok) {
+            const d: any = await res.json();
+            if (d?.id && pilotIds.includes(d.id)) {
+              viaDefault = d.id;
+            }
+          }
+        } catch {
+          // Ignore; fall back to the first device below.
+        }
+        chosen = viaDefault ?? pilotIds[0];
+      }
+    }
+    if (!pilotIds.includes(chosen)) {
+      return empty(true, {
+        pilotIds,
+        error: `Autopilot '${chosen}' not found; available: ${pilotIds.join(', ')}`,
+      });
+    }
+
+    // 3) Read the chosen device's status.
+    try {
+      const response = await this.fetchJson(
+        `${base}/${encodeURIComponent(chosen)}`,
+      );
+      if (!response.ok) {
+        return empty(true, {
+          pilotId: chosen,
+          pilotIds,
+          error: `Autopilot '${chosen}' status unavailable (HTTP ${response.status})`,
+        });
+      }
+      const dev: any = await response.json();
+      const targetRadians = typeof dev?.target === 'number' ? dev.target : null;
+      return {
+        available: true,
+        connected: this.connected,
+        pilotId: chosen,
+        pilotIds,
+        engaged: typeof dev?.engaged === 'boolean' ? dev.engaged : null,
+        state: dev?.state ?? null,
+        mode: dev?.mode ?? null,
+        targetRadians,
+        targetDegrees:
+          targetRadians !== null ? targetRadians * (180 / Math.PI) : null,
+        options: dev?.options ?? null,
+        timestamp: now(),
+      };
+    } catch (error: any) {
+      console.error('Failed to fetch autopilot status via HTTP:', error.message);
+      return empty(true, {
+        pilotId: chosen,
+        pilotIds,
+        error: `Autopilot status request failed: ${error?.message || String(error)}`,
+      });
+    }
   }
 
   /**

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,7 +270,7 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(10);
+      expect(result.tools).toHaveLength(11);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
@@ -280,6 +280,7 @@ describe('SignalKMCPServer', () => {
         'get_history',
         'list_history_paths',
         'list_history_contexts',
+        'get_course_status',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,13 +270,16 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(7);
+      expect(result.tools).toHaveLength(10);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
         'get_active_alarms',
         'list_available_paths',
         'get_path_value',
+        'get_history',
+        'list_history_paths',
+        'list_history_contexts',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,7 +270,7 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(11);
+      expect(result.tools).toHaveLength(12);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
@@ -281,6 +281,7 @@ describe('SignalKMCPServer', () => {
         'list_history_paths',
         'list_history_contexts',
         'get_course_status',
+        'get_autopilot_status',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -60,6 +60,8 @@ jest.mock('./signalk-client', () => ({
     getWeatherObservations: jest.fn(),
     getWeatherForecast: jest.fn(),
     getWeatherWarnings: jest.fn(),
+    getServerInfo: jest.fn(),
+    getServerFeatures: jest.fn(),
     getConnectionStatus: jest.fn(),
     disconnect: jest.fn(),
     buildWebSocketUrl: jest.fn(),
@@ -128,6 +130,8 @@ describe('SignalKMCPServer', () => {
       getWeatherObservations: jest.fn(),
       getWeatherForecast: jest.fn(),
       getWeatherWarnings: jest.fn(),
+    getServerInfo: jest.fn(),
+    getServerFeatures: jest.fn(),
       getConnectionStatus: jest.fn(),
       disconnect: jest.fn(),
       buildWebSocketUrl: jest.fn(),
@@ -701,8 +705,8 @@ describe('SignalKMCPServer', () => {
       expect(JSON.parse(result.content[0].text)).toEqual(mockData);
     });
 
-    test('getInitialContext should return formatted response', () => {
-      const result = server.getInitialContext();
+    test('getInitialContext should return formatted response', async () => {
+      const result = await server.getInitialContext();
 
       expect(result.content[0].type).toBe('text');
       const parsedResult = JSON.parse(result.content[0].text);
@@ -711,6 +715,41 @@ describe('SignalKMCPServer', () => {
       expect(parsedResult.server_info).toHaveProperty('version');
       expect(parsedResult.server_info).toHaveProperty('loaded_at');
       expect(parsedResult.server_info).toHaveProperty('description');
+    });
+
+    test('getInitialContext folds in live server features and memoizes discovery', async () => {
+      (mockSignalKClient as any).getServerInfo.mockResolvedValue({
+        available: true,
+        connected: true,
+        name: 'signalk-server-node',
+        version: '0.0.0',
+        endpoints: {},
+        timestamp: 't',
+      });
+      (mockSignalKClient as any).getServerFeatures.mockResolvedValue({
+        available: true,
+        connected: true,
+        apis: ['weather', 'history'],
+        plugins: [],
+        timestamp: 't',
+      });
+
+      const first = await server.getInitialContext();
+      const second = await server.getInitialContext();
+
+      const parsed = JSON.parse(first.content[0].text);
+      expect(parsed).toHaveProperty('server_features');
+      expect(parsed.server_features.apis).toEqual(['weather', 'history']);
+      expect(parsed.server_info.signalk_server).toEqual({
+        id: 'signalk-server-node',
+        version: '0.0.0',
+      });
+      // Memoized: discovery runs once across both calls.
+      expect((mockSignalKClient as any).getServerInfo).toHaveBeenCalledTimes(1);
+      expect(
+        (mockSignalKClient as any).getServerFeatures,
+      ).toHaveBeenCalledTimes(1);
+      expect(second.content[0].text).toBe(first.content[0].text);
     });
   });
 

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -270,7 +270,7 @@ describe('SignalKMCPServer', () => {
         .calls[0][1] as () => any;
       const result = await listToolsHandler();
 
-      expect(result.tools).toHaveLength(12);
+      expect(result.tools).toHaveLength(15);
       expect(result.tools.map((tool: any) => tool.name)).toEqual([
         'get_vessel_state',
         'get_ais_targets',
@@ -282,6 +282,9 @@ describe('SignalKMCPServer', () => {
         'list_history_contexts',
         'get_course_status',
         'get_autopilot_status',
+        'get_weather_observations',
+        'get_weather_forecast',
+        'get_weather_warnings',
         'get_connection_status',
         'get_initial_context',
       ]);

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -52,6 +52,14 @@ jest.mock('./signalk-client', () => ({
     getActiveAlarms: jest.fn(),
     listAvailablePaths: jest.fn(),
     getPathValue: jest.fn(),
+    getHistory: jest.fn(),
+    listHistoryPaths: jest.fn(),
+    listHistoryContexts: jest.fn(),
+    getCourseStatus: jest.fn(),
+    getAutopilotStatus: jest.fn(),
+    getWeatherObservations: jest.fn(),
+    getWeatherForecast: jest.fn(),
+    getWeatherWarnings: jest.fn(),
     getConnectionStatus: jest.fn(),
     disconnect: jest.fn(),
     buildWebSocketUrl: jest.fn(),
@@ -112,6 +120,14 @@ describe('SignalKMCPServer', () => {
       getActiveAlarms: jest.fn(),
       listAvailablePaths: jest.fn(),
       getPathValue: jest.fn(),
+      getHistory: jest.fn(),
+      listHistoryPaths: jest.fn(),
+      listHistoryContexts: jest.fn(),
+      getCourseStatus: jest.fn(),
+      getAutopilotStatus: jest.fn(),
+      getWeatherObservations: jest.fn(),
+      getWeatherForecast: jest.fn(),
+      getWeatherWarnings: jest.fn(),
       getConnectionStatus: jest.fn(),
       disconnect: jest.fn(),
       buildWebSocketUrl: jest.fn(),
@@ -510,6 +526,72 @@ describe('SignalKMCPServer', () => {
       await expect(callToolHandler(request)).rejects.toThrow(
         'Tool execution failed: Tool execution failed',
       );
+    });
+
+    // The v2 read tools (history, course, autopilot, weather) must be directly
+    // callable in tools/hybrid mode - not just advertised in the tools list.
+    // Each dispatches to the matching client method and wraps the result.
+    describe('v2 read tools dispatch in tools mode', () => {
+      const cases: Array<{
+        tool: string;
+        method: string;
+        args: any;
+        expectArgs?: any[];
+      }> = [
+        {
+          tool: 'get_history',
+          method: 'getHistory',
+          args: {
+            paths: 'navigation.position',
+            from: '2026-06-12T00:00:00Z',
+            to: '2026-06-12T01:00:00Z',
+          },
+        },
+        { tool: 'list_history_paths', method: 'listHistoryPaths', args: {} },
+        {
+          tool: 'list_history_contexts',
+          method: 'listHistoryContexts',
+          args: {},
+        },
+        { tool: 'get_course_status', method: 'getCourseStatus', args: {} },
+        {
+          tool: 'get_autopilot_status',
+          method: 'getAutopilotStatus',
+          args: { pilotId: 'pilot-a' },
+          expectArgs: ['pilot-a'],
+        },
+        {
+          tool: 'get_weather_observations',
+          method: 'getWeatherObservations',
+          args: { latitude: 38.97, longitude: -76.5 },
+        },
+        {
+          tool: 'get_weather_forecast',
+          method: 'getWeatherForecast',
+          args: { type: 'daily' },
+        },
+        { tool: 'get_weather_warnings', method: 'getWeatherWarnings', args: {} },
+      ];
+
+      cases.forEach(({ tool, method, args, expectArgs }) => {
+        test(`dispatches ${tool} to client.${method}`, async () => {
+          const mockData = { ok: true, tool };
+          (mockSignalKClient as any)[method].mockResolvedValue(mockData);
+
+          const result = await callToolHandler({
+            params: { name: tool, arguments: args },
+          });
+
+          expect((mockSignalKClient as any)[method]).toHaveBeenCalledTimes(1);
+          if (expectArgs) {
+            expect((mockSignalKClient as any)[method]).toHaveBeenCalledWith(
+              ...expectArgs,
+            );
+          }
+          expect(result.content[0].type).toBe('text');
+          expect(JSON.parse(result.content[0].text)).toEqual(mockData);
+        });
+      });
     });
   });
 

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -476,6 +476,26 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_autopilot_status',
+        description:
+          'Get autopilot status (read-only): whether it is engaged, its state and ' +
+          'mode, the target heading (in degrees), and the available states / modes ' +
+          '/ actions. Reads the default autopilot, or pass pilotId for a specific ' +
+          'device. Returns available:false when there is no autopilot API. This ' +
+          'does NOT control the autopilot.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pilotId: {
+              type: 'string',
+              description:
+                'Optional autopilot device id (defaults to the vessel default)',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -552,7 +572,7 @@ export class SignalKMCPServer {
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
             'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
-            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(). ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(), await getAutopilotStatus(pilotId?). ' +
             'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
@@ -627,7 +647,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus(), getAutopilotStatus()`,
               );
           }
         } catch (error: any) {

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -728,6 +728,46 @@ export class SignalKMCPServer {
                 return await this.listAvailablePaths();
               case 'get_path_value':
                 return await this.getPathValue(args?.path);
+              case 'get_history':
+                return this.wrapToolResult(
+                  await this.signalkClient.getHistory(args),
+                  'getHistory()',
+                );
+              case 'list_history_paths':
+                return this.wrapToolResult(
+                  await this.signalkClient.listHistoryPaths(args),
+                  'listHistoryPaths()',
+                );
+              case 'list_history_contexts':
+                return this.wrapToolResult(
+                  await this.signalkClient.listHistoryContexts(args),
+                  'listHistoryContexts()',
+                );
+              case 'get_course_status':
+                return this.wrapToolResult(
+                  await this.signalkClient.getCourseStatus(),
+                  'getCourseStatus()',
+                );
+              case 'get_autopilot_status':
+                return this.wrapToolResult(
+                  await this.signalkClient.getAutopilotStatus(args?.pilotId),
+                  'getAutopilotStatus()',
+                );
+              case 'get_weather_observations':
+                return this.wrapToolResult(
+                  await this.signalkClient.getWeatherObservations(args),
+                  'getWeatherObservations()',
+                );
+              case 'get_weather_forecast':
+                return this.wrapToolResult(
+                  await this.signalkClient.getWeatherForecast(args),
+                  'getWeatherForecast()',
+                );
+              case 'get_weather_warnings':
+                return this.wrapToolResult(
+                  await this.signalkClient.getWeatherWarnings(args),
+                  'getWeatherWarnings()',
+                );
               case 'get_connection_status':
                 return this.getConnectionStatus();
               case 'get_initial_context':
@@ -917,6 +957,32 @@ export class SignalKMCPServer {
         `Code execution failed: ${error.message}`,
       );
     }
+  }
+
+  /**
+   * Wrap a client result as an MCP text response, mirroring the legacy tool
+   * handlers. Used by the v2 read tools (history, course, autopilot, weather)
+   * so they are directly callable in tools/hybrid mode, not just advertised.
+   *
+   * @param data - the value returned by the SignalK client method
+   * @param sdkHint - the execute_code SDK call to suggest in hybrid mode
+   * @returns MCPToolResponse with the data as formatted JSON text
+   */
+  private wrapToolResult(data: unknown, sdkHint: string): MCPToolResponse {
+    const deprecationNotice =
+      this.executionMode === 'hybrid'
+        ? '\n⚠️ DEPRECATION WARNING: This tool will be removed in a future version. ' +
+          `Use execute_code with ${sdkHint} instead.\n`
+        : '';
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: deprecationNotice + JSON.stringify(data, null, 2),
+        },
+      ],
+    };
   }
 
   /**

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -72,6 +72,8 @@ export class SignalKMCPServer {
   private sandbox?: IsolateSandbox;
   private binding?: SignalKBinding;
   private sdkCode?: string;
+  // Memoized initial context (built once live discovery has answered).
+  private cachedInitialContext?: MCPToolResponse;
 
   /**
    * Creates a new SignalK MCP Server instance with configuration from options or environment variables
@@ -771,7 +773,7 @@ export class SignalKMCPServer {
               case 'get_connection_status':
                 return this.getConnectionStatus();
               case 'get_initial_context':
-                return this.getInitialContext();
+                return await this.getInitialContext();
               default:
                 throw new McpError(
                   ErrorCode.MethodNotFound,
@@ -785,7 +787,7 @@ export class SignalKMCPServer {
             case 'get_connection_status':
               return this.getConnectionStatus();
             case 'get_initial_context':
-              return this.getInitialContext();
+              return await this.getInitialContext();
             default:
               // Data-fetching tools not available in code mode
               throw new McpError(
@@ -1204,7 +1206,11 @@ export class SignalKMCPServer {
    * //   }
    * // }
    */
-  getInitialContext(): MCPToolResponse {
+  async getInitialContext(): Promise<MCPToolResponse> {
+    if (this.cachedInitialContext) {
+      return this.cachedInitialContext;
+    }
+
     const contextData: Record<string, any> = {
       server_info: {
         name: this.serverName,
@@ -1215,13 +1221,33 @@ export class SignalKMCPServer {
       },
     };
 
+    // Best-effort live discovery: the client uses a short timeout and degrades
+    // gracefully, so this stays fast (and never throws) when the SignalK server
+    // is unreachable. The available APIs tell an agent which reads will work.
+    const [info, features] = await Promise.all([
+      this.signalkClient.getServerInfo(),
+      this.signalkClient.getServerFeatures(),
+    ]);
+    if (info?.available) {
+      contextData.server_info.signalk_server = {
+        id: info.name,
+        version: info.version,
+      };
+    }
+    if (features?.available) {
+      contextData.server_features = {
+        apis: features.apis,
+        plugins: features.plugins,
+      };
+    }
+
     // Load all available resources
     for (const [uri, content] of this.resources.entries()) {
       const resourceKey = uri.replace('signalk://', '');
       contextData[resourceKey] = content;
     }
 
-    return {
+    const response: MCPToolResponse = {
       content: [
         {
           type: 'text',
@@ -1229,6 +1255,13 @@ export class SignalKMCPServer {
         },
       ],
     };
+
+    // Memoize only once the server has actually answered, so a transient outage
+    // at startup doesn't pin a degraded context for the whole session.
+    if (info?.available || features?.available) {
+      this.cachedInitialContext = response;
+    }
+    return response;
   }
 
   /**

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -462,6 +462,20 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_course_status',
+        description:
+          'Get the current navigation course: the active route/destination plus ' +
+          'calculated values (cross-track error, bearing to the next waypoint, ETA, ' +
+          'velocity made good, time-to-go). Returns navigating:false with ' +
+          'calcValues:null when no destination is set. Requires a SignalK v2 server. ' +
+          'Check result.available.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -538,7 +552,7 @@ export class SignalKMCPServer {
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
             'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
-            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options). ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(). ' +
             'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
@@ -613,7 +627,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus()`,
               );
           }
         } catch (error: any) {

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -496,6 +496,109 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_weather_observations',
+        description:
+          'Get current weather observations for the vessel position (read-only): ' +
+          'air/water temperature, wind, pressure, humidity, waves, current, etc. ' +
+          'Defaults to the vessel position; pass latitude/longitude to query ' +
+          'elsewhere. Returns available:false (reason:"no vessel position") when ' +
+          'there is no position fix, and available:false when there is no weather ' +
+          'provider. Values are SI (kelvin, m/s, radians, pascals).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            latitude: {
+              type: 'number',
+              description: 'Latitude (defaults to the vessel position)',
+            },
+            longitude: {
+              type: 'number',
+              description: 'Longitude (defaults to the vessel position)',
+            },
+            provider: {
+              type: 'string',
+              description: 'Weather provider id (defaults to the server default)',
+            },
+            count: {
+              type: 'number',
+              description: 'Max number of entries to return',
+            },
+            date: {
+              type: 'string',
+              description: 'Start date as YYYY-MM-DD',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'get_weather_forecast',
+        description:
+          'Get a weather forecast for the vessel position (read-only). type is ' +
+          "'daily' (per-day summary) or 'point' (per time-point series); defaults " +
+          "to 'daily'. Defaults to the vessel position; pass latitude/longitude to " +
+          'query elsewhere. Returns available:false (reason:"no vessel position") ' +
+          'when there is no position fix. Values are SI (kelvin, m/s, radians, pascals).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['daily', 'point'],
+              description: "Forecast resolution: 'daily' or 'point' (default 'daily')",
+            },
+            latitude: {
+              type: 'number',
+              description: 'Latitude (defaults to the vessel position)',
+            },
+            longitude: {
+              type: 'number',
+              description: 'Longitude (defaults to the vessel position)',
+            },
+            provider: {
+              type: 'string',
+              description: 'Weather provider id (defaults to the server default)',
+            },
+            count: {
+              type: 'number',
+              description: 'Max number of entries to return',
+            },
+            date: {
+              type: 'string',
+              description: 'Start date as YYYY-MM-DD',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'get_weather_warnings',
+        description:
+          'Get active weather warnings for the vessel position (read-only), e.g. ' +
+          'gale or storm advisories. Defaults to the vessel position; pass ' +
+          'latitude/longitude to query elsewhere. Returns available:false ' +
+          '(reason:"no vessel position") when there is no position fix. data is ' +
+          'the list of warnings (empty when none).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            latitude: {
+              type: 'number',
+              description: 'Latitude (defaults to the vessel position)',
+            },
+            longitude: {
+              type: 'number',
+              description: 'Longitude (defaults to the vessel position)',
+            },
+            provider: {
+              type: 'string',
+              description: 'Weather provider id (defaults to the server default)',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -572,7 +675,8 @@ export class SignalKMCPServer {
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
             'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
-            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(), await getAutopilotStatus(pilotId?). ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options), await getCourseStatus(), await getAutopilotStatus(pilotId?), ' +
+            'await getWeatherObservations(options?), await getWeatherForecast({type}?), await getWeatherWarnings(options?). ' +
             'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
@@ -647,7 +751,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus(), getAutopilotStatus()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts(), getCourseStatus(), getAutopilotStatus(), getWeatherObservations(), getWeatherForecast(), getWeatherWarnings()`,
               );
           }
         } catch (error: any) {

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -374,6 +374,94 @@ export class SignalKMCPServer {
         },
       },
       {
+        name: 'get_history',
+        description:
+          'Query aggregated historical time-series for one or more SignalK paths. ' +
+          'Requires a SignalK server with a history provider (e.g. signalk-to-influxdb); ' +
+          'if none is installed the result has available:false. ' +
+          'Times are ISO-8601 (e.g. 2026-06-11T06:00:00Z); resolution is in SECONDS; ' +
+          'provide "from" or "duration". Aggregation can be set inline per path ' +
+          '(e.g. "navigation.speedOverGround:max"). Returns a per-path map of ' +
+          '{timestamp, value} points; navigation.position values are [longitude, latitude] ' +
+          'arrays (NOT {latitude, longitude}), and null marks a gap. Best used inside ' +
+          'execute_code so you can aggregate before returning.\n\n' +
+          'Example:\n' +
+          '```javascript\n' +
+          '(async () => {\n' +
+          "  const h = await getHistory({ paths: 'navigation.speedOverGround:max', from: '2026-06-11T06:00:00Z', to: '2026-06-11T12:00:00Z', resolution: 300 });\n" +
+          '  if (!h.available) return JSON.stringify({ note: h.error });\n' +
+          "  const pts = h.values['navigation.speedOverGround'].filter(p => p.value != null);\n" +
+          '  return JSON.stringify({ maxKn: (Math.max(...pts.map(p => p.value)) * 1.94384).toFixed(1) });\n' +
+          '})();\n' +
+          '```',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            paths: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'SignalK path(s), optionally with an inline aggregation method (path:method[:param]), ' +
+                'e.g. ["navigation.speedOverGround:sma:5", "navigation.position"]',
+            },
+            from: {
+              type: 'string',
+              description: 'ISO-8601 start time (provide "from" or "duration")',
+            },
+            to: { type: 'string', description: 'ISO-8601 end time (defaults to now)' },
+            duration: {
+              type: 'string',
+              description: 'ISO-8601 duration (PT1H) or seconds; use instead of "from"',
+            },
+            resolution: {
+              type: 'number',
+              description: 'Bucket size in SECONDS (e.g. 60 = 1-minute buckets)',
+            },
+            aggregate: {
+              type: 'string',
+              description:
+                'Default aggregation for bare paths: average|min|max|first|last (default average)',
+            },
+            context: { type: 'string', description: 'Vessel context (default vessels.self)' },
+          },
+          required: ['paths'],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'list_history_paths',
+        description:
+          'List SignalK paths that have historical data in a time window. ' +
+          'Returns available:false when no history provider is installed. ' +
+          'Defaults to the last 24 hours when no time window is given.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'ISO-8601 start time' },
+            to: { type: 'string', description: 'ISO-8601 end time' },
+            duration: { type: 'string', description: 'ISO-8601 duration (P1D) or seconds' },
+            context: { type: 'string', description: 'Vessel context filter' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: 'list_history_contexts',
+        description:
+          'List vessel contexts that have historical data in a time window. ' +
+          'Returns available:false when no history provider is installed. ' +
+          'Useful to discover which vessels have history before calling get_history.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', description: 'ISO-8601 start time' },
+            to: { type: 'string', description: 'ISO-8601 end time' },
+            duration: { type: 'string', description: 'ISO-8601 duration (P1D) or seconds' },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: 'get_connection_status',
         description: 'Get SignalK connection status and health. Useful for debugging and troubleshooting connectivity issues.',
         inputSchema: {
@@ -449,7 +537,9 @@ export class SignalKMCPServer {
             'Execute JavaScript code in a secure V8 isolate with access to SignalK SDK functions. ' +
             'IMPORTANT: ALL SDK functions are async and MUST be awaited, including getConnectionStatus(). ' +
             'Available functions: await getVesselState(), await getAisTargets(options), ' +
-            'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(). ' +
+            'await getActiveAlarms(), await listAvailablePaths(), await getPathValue(path), await getConnectionStatus(), ' +
+            'await getHistory({paths, from, to, resolution}), await listHistoryPaths(options), await listHistoryContexts(options). ' +
+            'History needs a SignalK history provider - check result.available; times are ISO-8601 and resolution is in SECONDS. ' +
             'Code MUST: (1) be wrapped in async IIFE, (2) await all SDK calls, (3) return JSON.stringify() of result. ' +
             'Example: (async () => { const vessel = await getVesselState(); return JSON.stringify({ name: vessel.data.name?.value }); })()',
           inputSchema: {
@@ -523,7 +613,7 @@ export class SignalKMCPServer {
               throw new McpError(
                 ErrorCode.MethodNotFound,
                 `Tool ${name} is not available in code-only mode. Use execute_code tool with SignalK SDK functions instead. ` +
-                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue()`,
+                `Available SDK functions: getVesselState(), getAisTargets(), getActiveAlarms(), listAvailablePaths(), getPathValue(), getHistory(), listHistoryPaths(), listHistoryContexts()`,
               );
           }
         } catch (error: any) {

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -474,6 +474,9 @@ describe('Tool Migration Tests', () => {
             'execute_code',
             'get_initial_context',
             'get_connection_status',
+            'get_history',
+            'list_history_paths',
+            'list_history_contexts',
           ].includes(t.name)
       );
 

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -85,6 +85,7 @@ jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
 
 import { SignalKMCPServer } from './signalk-mcp-server.js';
 import { SignalKClient } from './signalk-client.js';
+import { SignalKBinding } from './bindings/signalk-binding.js';
 
 // Mock the SignalK client
 jest.mock('./signalk-client', () => ({
@@ -553,6 +554,35 @@ describe('Tool Migration Tests', () => {
 
       // Should be valid async IIFE pattern
       expect(code.trim().endsWith('})();')).toBe(true);
+    });
+  });
+
+  describe('Tool/binding parity', () => {
+    // Direct-only utility tools: handled by the server, not exposed inside the
+    // isolate as SDK functions that call the binding.
+    const DIRECT_ONLY = ['execute_code', 'get_initial_context'];
+    const toCamelCase = (s: string): string =>
+      s.replace(/_([a-z])/g, (_m: string, c: string) => c.toUpperCase());
+
+    it('every tool definition has a matching camelCase method on SignalKBinding', () => {
+      new SignalKMCPServer({ executionMode: 'hybrid' });
+      const listToolsHandler = mockServer.setRequestHandler.mock.calls.find(
+        (call) => call[0] === 'ListToolsRequestSchema'
+      )?.[1] as any;
+      const tools = listToolsHandler().tools as Array<{ name: string }>;
+
+      const bindingMethods = Object.getOwnPropertyNames(
+        SignalKBinding.prototype
+      );
+      const missing = tools
+        .map((t) => t.name)
+        .filter((name) => !DIRECT_ONLY.includes(name))
+        .filter((name) => !bindingMethods.includes(toCamelCase(name)));
+
+      // The isolate SDK is auto-generated from tool names via the same
+      // camelCase rule (generator.ts); a tool without a matching binding method
+      // would be a broken SDK function inside execute_code.
+      expect(missing).toEqual([]);
     });
   });
 });

--- a/src/tool-migration.spec.ts
+++ b/src/tool-migration.spec.ts
@@ -116,7 +116,7 @@ describe('Tool Migration Tests', () => {
       data: {
         name: { value: 'Test Vessel' },
         'navigation.position': {
-          value: { latitude: 37.8199, longitude: -122.4783 },
+          value: { latitude: 38.9784, longitude: -76.4922 },
         },
         'navigation.speedOverGround': { value: 5.2 },
         'navigation.courseOverGroundTrue': { value: 1.57 },
@@ -222,8 +222,8 @@ describe('Tool Migration Tests', () => {
 
       // Should also have actual data
       expect(text).toContain('Test Vessel');
-      expect(text).toContain('37.8199');
-      expect(text).toContain('-122.4783');
+      expect(text).toContain('38.9784');
+      expect(text).toContain('-76.4922');
     });
 
     it('should have execute_code tool available in hybrid mode', () => {
@@ -336,7 +336,7 @@ describe('Tool Migration Tests', () => {
       // Simulate filtered result (just name and position)
       const filteredData = {
         name: 'Test Vessel',
-        position: { latitude: 37.8199, longitude: -122.4783 },
+        position: { latitude: 38.9784, longitude: -76.4922 },
       };
       const filteredText = JSON.stringify(filteredData, null, 2);
       const filteredSize = filteredText.length;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,12 @@ export type {
   AvailablePathsResponse,
   PathValueResponse,
   ConnectionStatus,
+  HistoryDataPoint,
+  HistoryQueryOptions,
+  HistorySeries,
+  HistoryResponse,
+  HistoryPathsResponse,
+  HistoryContextsResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,8 @@ export type {
   HistoryContextsResponse,
   CourseStatusResponse,
   AutopilotStatusResponse,
+  WeatherQueryOptions,
+  WeatherResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,7 @@ export type {
   HistoryPathsResponse,
   HistoryContextsResponse,
   CourseStatusResponse,
+  AutopilotStatusResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export type {
   HistoryResponse,
   HistoryPathsResponse,
   HistoryContextsResponse,
+  CourseStatusResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,8 @@ export type {
   AutopilotStatusResponse,
   WeatherQueryOptions,
   WeatherResponse,
+  ServerInfoResponse,
+  ServerFeaturesResponse,
 } from './interfaces';
 
 export type {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -154,3 +154,17 @@ export interface HistoryContextsResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface CourseStatusResponse {
+  available: boolean;
+  connected: boolean;
+  // false when there is no active destination / route
+  navigating: boolean;
+  // the raw /navigation/course body (activeRoute, nextPoint, arrivalCircle, ...)
+  course: any | null;
+  // /navigation/course/calcValues (distance, bearing, ETA, cross-track error,
+  // VMG, time-to-go) - null when not navigating or unavailable
+  calcValues: any | null;
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -169,3 +169,23 @@ export interface CourseStatusResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface AutopilotStatusResponse {
+  available: boolean;
+  connected: boolean;
+  // the autopilot device that was read (the default, or the requested pilotId)
+  pilotId: string | null;
+  // ids of all autopilot devices on the vessel
+  pilotIds: string[];
+  engaged: boolean | null;
+  state: string | null;
+  mode: string | null;
+  // target heading converted to degrees, or null when there is no target
+  targetDegrees: number | null;
+  // raw target heading in radians (SignalK SI), or null
+  targetRadians: number | null;
+  // available states / modes / actions for the device
+  options: any;
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -16,6 +16,10 @@ export interface ActiveAlarm {
   state: string;
   message: string;
   timestamp?: string;
+  // alert methods the notification requests, e.g. ['visual', 'sound']
+  method?: string[];
+  // notification management status (silenced / acknowledged / canSilence / ...)
+  status?: Record<string, any>;
 }
 
 export interface VesselState {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -224,3 +224,26 @@ export interface WeatherResponse {
   reason?: string;
   error?: string;
 }
+
+export interface ServerInfoResponse {
+  available: boolean;
+  connected: boolean;
+  // the SignalK server implementation id and version, or null when unavailable
+  name: string | null;
+  version: string | null;
+  // the raw endpoints block from GET /signalk (versions -> urls)
+  endpoints: any;
+  timestamp: string;
+  error?: string;
+}
+
+export interface ServerFeaturesResponse {
+  available: boolean;
+  connected: boolean;
+  // names of the APIs the server implements (e.g. 'course', 'weather', 'history')
+  apis: string[];
+  // installed plugins ({ id, name, version })
+  plugins: any[];
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -80,3 +80,77 @@ export interface PathValueResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface HistoryDataPoint {
+  timestamp: string;
+  // Aggregated value for one time bucket. May be a scalar (number / string /
+  // boolean), a position [longitude, latitude] array (GeoJSON order, unlike the
+  // live API's {latitude, longitude}), or null for a gap with no data.
+  value: number | number[] | string | boolean | null;
+}
+
+export interface HistoryQueryOptions {
+  // One or more SignalK paths. Each entry may include an inline aggregation
+  // method: 'path', 'path:method', or 'path:method:param'
+  // (e.g. 'navigation.speedOverGround:sma:5').
+  paths: string | string[];
+  // ISO-8601 start time. At least one of `from` or `duration` is required.
+  from?: string;
+  // ISO-8601 end time (defaults to now on the server).
+  to?: string;
+  // ISO-8601 duration ('PT1H') or whole seconds; use instead of `from`/`to`.
+  duration?: string | number;
+  // Bucket size in SECONDS (not milliseconds).
+  resolution?: number;
+  // Default aggregation method applied to bare paths (e.g. 'average', 'max').
+  aggregate?: string;
+  // Vessel context (default 'vessels.self').
+  context?: string;
+  // Optional history provider id (e.g. 'signalk-to-influxdb2').
+  provider?: string;
+}
+
+export interface HistorySeries {
+  path: string;
+  method: string;
+  points: HistoryDataPoint[];
+}
+
+export interface HistoryResponse {
+  // True when the history provider answered (even if the window was empty).
+  // False only when no history provider is installed/reachable.
+  available: boolean;
+  connected: boolean;
+  context?: string;
+  range?: { from: string; to: string };
+  resolution?: number;
+  requestedPaths: string[];
+  // One entry per response column, in server order (never lossy).
+  series: HistorySeries[];
+  // Convenience map keyed by path. If the same path is requested with two
+  // methods, the last one wins here - use `series` to keep both.
+  values: Record<string, HistoryDataPoint[]>;
+  // Requested paths the server returned no column for.
+  missingPaths: string[];
+  rowCount?: number;
+  timestamp: string;
+  error?: string;
+}
+
+export interface HistoryPathsResponse {
+  available: boolean;
+  connected: boolean;
+  count: number;
+  paths: string[];
+  timestamp: string;
+  error?: string;
+}
+
+export interface HistoryContextsResponse {
+  available: boolean;
+  connected: boolean;
+  count: number;
+  contexts: string[];
+  timestamp: string;
+  error?: string;
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -160,11 +160,12 @@ export interface CourseStatusResponse {
   connected: boolean;
   // false when there is no active destination / route
   navigating: boolean;
-  // the raw /navigation/course body (activeRoute, nextPoint, arrivalCircle, ...)
-  course: any | null;
+  // the raw /navigation/course body (activeRoute, nextPoint, arrivalCircle, ...),
+  // or null when unavailable
+  course: any;
   // /navigation/course/calcValues (distance, bearing, ETA, cross-track error,
-  // VMG, time-to-go) - null when not navigating or unavailable
-  calcValues: any | null;
+  // VMG, time-to-go), or null when not navigating or unavailable
+  calcValues: any;
   timestamp: string;
   error?: string;
 }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -189,3 +189,38 @@ export interface AutopilotStatusResponse {
   timestamp: string;
   error?: string;
 }
+
+export interface WeatherQueryOptions {
+  // Position to query. Defaults to the vessel's current position when omitted.
+  latitude?: number;
+  longitude?: number;
+  // Weather provider plugin id. Defaults to the server's default provider.
+  provider?: string;
+  // Max number of entries to return (observations / forecast only).
+  count?: number;
+  // Start date as YYYY-MM-DD (observations / forecast only).
+  date?: string;
+  // Forecast resolution: 'daily' (per-day) or 'point' (per time point).
+  // Ignored by observations and warnings.
+  type?: 'daily' | 'point';
+}
+
+export interface WeatherResponse {
+  available: boolean;
+  connected: boolean;
+  // 'observations' | 'forecast' | 'warnings'
+  kind: string;
+  // 'daily' | 'point' for forecasts; null for observations / warnings
+  forecastType: string | null;
+  // the position the weather was requested for, or null when there is no fix
+  position: { latitude: number; longitude: number } | null;
+  // the provider id that was requested, or null when the server default was used
+  provider: string | null;
+  // the raw weather entries (WeatherDataModel[] or WeatherWarningModel[]); SI units
+  data: any[];
+  count: number;
+  timestamp: string;
+  // why the data is unavailable, e.g. 'no vessel position'
+  reason?: string;
+  error?: string;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -54,7 +54,7 @@ global.testUtils = {
   createSampleDelta: (
     context = 'vessels.self',
     path = 'navigation.position',
-    value = { latitude: 37.8199, longitude: -122.4783 },
+    value = { latitude: 38.9784, longitude: -76.4922 },
   ) => ({
     context,
     updates: [

--- a/tests/signalk-client-get-active-alarms.e2e.spec.ts
+++ b/tests/signalk-client-get-active-alarms.e2e.spec.ts
@@ -140,6 +140,16 @@ describe('SignalK Client getActiveAlarms - Live Integration', () => {
           expect(alarm.message.length).toBeGreaterThan(0);
         }
 
+        // Optional enrichment - the alert methods and management status are
+        // only present when the server provides them, but must be well-typed.
+        if (alarm.method !== undefined) {
+          expect(Array.isArray(alarm.method)).toBe(true);
+        }
+        if (alarm.status !== undefined) {
+          expect(typeof alarm.status).toBe('object');
+          expect(alarm.status).not.toBeNull();
+        }
+
         // Timestamp validation
         expect(alarm.timestamp).toBeDefined();
         expect(typeof alarm.timestamp).toBe('string');

--- a/tests/signalk-client-history.e2e.spec.ts
+++ b/tests/signalk-client-history.e2e.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * SignalK Client History API Integration Tests
+ *
+ * Exercises getHistory/listHistoryPaths/listHistoryContexts against a live
+ * SignalK server. The History API needs a history provider plugin (for example
+ * signalk-to-influxdb); these tests probe for it in beforeAll and SKIP
+ * gracefully (still passing) when it is absent, so they do not fail on a vanilla
+ * server such as the Docker CI image (which runs with DISABLEPLUGINS=true).
+ *
+ * To run against a history-enabled server, point SIGNALK_HOST/PORT/TLS at it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { SignalKClient } from '../src/signalk-client.js';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('SignalK Client History API - Live Integration', () => {
+  let client: SignalKClient;
+  let historyEnabled = false;
+  let knownPaths: string[] = [];
+
+  const CONNECTION_TIMEOUT = 30000;
+
+  beforeAll(async () => {
+    client = new SignalKClient({
+      hostname: process.env.SIGNALK_HOST,
+      port: parseInt(process.env.SIGNALK_PORT || '3000'),
+      useTLS: process.env.SIGNALK_TLS === 'true',
+      context: process.env.SIGNALK_CONTEXT || 'vessels.self',
+    });
+
+    try {
+      await client.connect();
+    } catch (error) {
+      console.log(
+        `History tests skipped - could not reach a SignalK server: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    // Probe for a history provider. available:false means none is installed.
+    const contexts = await client.listHistoryContexts();
+    if (!contexts.available) {
+      console.log(
+        'History tests skipped - SignalK server has no history provider installed',
+      );
+      return;
+    }
+    historyEnabled = true;
+
+    const paths = await client.listHistoryPaths();
+    knownPaths = paths.paths || [];
+    console.log(
+      `History provider present; ${knownPaths.length} historized paths found`,
+    );
+  }, CONNECTION_TIMEOUT);
+
+  afterAll(() => {
+    if (client && client.connected) {
+      client.disconnect();
+    }
+  });
+
+  test('listHistoryPaths reports an available provider and an array of paths', () => {
+    if (!historyEnabled) {
+      return; // skipped - no provider on this server
+    }
+    expect(Array.isArray(knownPaths)).toBe(true);
+  });
+
+  test(
+    'getHistory returns a bounded per-path series for a recent window',
+    async () => {
+      if (!historyEnabled) {
+        return; // skipped - no provider on this server
+      }
+
+      const preferred = [
+        'navigation.speedOverGround',
+        'navigation.position',
+      ].filter((p) => knownPaths.includes(p));
+      const target = preferred[0] || knownPaths[0];
+      if (!target) {
+        console.log('No historized paths to query - skipping');
+        return;
+      }
+
+      const to = new Date();
+      const from = new Date(to.getTime() - 60 * 60 * 1000); // last hour
+
+      const h = await client.getHistory({
+        paths: target,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        resolution: 300,
+      });
+
+      expect(h.available).toBe(true);
+      expect(h.requestedPaths).toContain(target);
+      expect(Array.isArray(h.series)).toBe(true);
+      // Bounded result: ~12 buckets for one hour at 300s, never the full table.
+      expect(typeof h.rowCount).toBe('number');
+      expect(h.rowCount as number).toBeLessThan(1000);
+
+      if (h.series.length > 0) {
+        const points = h.values[h.series[0].path];
+        expect(Array.isArray(points)).toBe(true);
+        if (points.length > 0) {
+          expect(points[0]).toHaveProperty('timestamp');
+          expect(points[0]).toHaveProperty('value');
+        }
+      }
+    },
+    CONNECTION_TIMEOUT,
+  );
+});


### PR DESCRIPTION
**Branch:** `alarm-enrichment` → targets `main` · **Stack position:** 8 of 12

## Stack & merge order

Part of a stack of read-only additions. Each branch builds on the one below it, and the
bottom of the stack builds on **#9 `feat/history-api`** (already open here, not yet merged).

GitHub only lets a PR target a branch that exists in this repository, and these parent
branches aren't on `main` yet — so **every PR in this stack targets `main`**, and its diff
currently includes the commits of everything beneath it. **Please review and merge them
bottom-up:** each PR's diff collapses to just its own changes once the PRs below it land.
(This PR is step 8; its diff is its own changes plus steps 1–7 and #9.)

| Step | PR | Branch |
|------|----|--------|
| prereq | #9 | `feat/history-api` — open here, **not yet merged** |
| 1 | #11 | `reliability-foundation` |
| 2 | #12 | `read-course-autopilot` |
| 3 | #13 | `read-weather` |
| 4 | #14 | `tools-mode-dispatch` |
| 5 | #15 | `standardize-example-coordinates` |
| 6 | #16 | `server-feature-discovery` |
| 7 | #17 | `anchor-watch-docs` |
| 8 | #18 | `alarm-enrichment` ⬅ **this PR** |
| 9 | #19 | `resources-reads` |
| 10 | #20 | `radar-targets` |
| 11 | #21 | `unified-targets` |
| 12 | #22 | `units-metadata-docs` |

---
## Summary

`get_active_alarms` previously returned only `state` and `message` for each
notification. SignalK notifications also carry the alert **methods** (e.g.
`visual`, `sound`) and a **management status** (silenced / acknowledged /
canSilence / …). This surfaces both so an agent can tell, for example, whether a
critical alarm has been acknowledged or is still sounding.

## What changed

- `ActiveAlarm` gains two **optional** fields: `method?: string[]` and
  `status?: Record<string, any>`.
- `getActiveAlarms` adds them **only when the server provides them**, so the
  existing `path` / `state` / `message` / `timestamp` contract is unchanged
  (no breakage for existing callers).

## Testing

- New unit test: a notification with `method` + `status` surfaces both, and the
  existing fields are unchanged.
- New unit test: a notification with neither omits both fields (stays backward
  compatible).
- The live e2e (`signalk-client-get-active-alarms.e2e.spec.ts`) now validates the
  new fields' types when they appear.
- `npm run typecheck`, `npm run test:unit`, `npm run lint` all clean.

## Notes

- Additive and backward compatible; no field was removed or renamed.

## Commits

```
Add alarm method/status enrichment with a failing test (red)
Enrich active alarms with method/status (green)
```
