### PR TITLE
Serve the direct read tools when isolated-vm is unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@modelcontextprotocol/sdk": "^0.5.0",
         "@signalk/client": "^2.3.0",
         "dotenv": "^16.4.5",
-        "isolated-vm": "^5.0.1",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -34,6 +33,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "isolated-vm": "^6.1.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2402,37 +2404,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2510,30 +2481,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2619,12 +2566,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.2.0",
@@ -2847,21 +2788,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -2875,15 +2801,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2910,15 +2827,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3002,15 +2910,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3380,15 +3279,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.2.tgz",
@@ -3579,12 +3469,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3649,12 +3533,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -3769,26 +3647,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3874,12 +3732,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3961,16 +3813,17 @@
       "license": "ISC"
     },
     "node_modules/isolated-vm": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-5.0.4.tgz",
-      "integrity": "sha512-RYUf/JC4ldWz/oi2BVs8a1XIprQ71q6eQPBwySaF5Apu0KMyf2gIpElbCyPh2OEmRT+FYw1GOKSdkv7jw2KLxw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
+      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
       "hasInstallScript": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
-        "prebuild-install": "^7.1.2"
+        "node-gyp-build": "^4.8.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/isomorphic-ws": {
@@ -4971,18 +4824,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4999,15 +4840,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -5018,22 +4850,10 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -5059,30 +4879,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-abi": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5101,6 +4897,18 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -5144,6 +4952,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5374,32 +5183,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5436,16 +5219,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -5511,50 +5284,12 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5624,26 +5359,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5700,51 +5415,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/slash": {
@@ -5805,15 +5475,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -6017,34 +5678,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {
@@ -6287,18 +5920,6 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6440,12 +6061,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -6629,6 +6244,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,10 @@
     "@modelcontextprotocol/sdk": "^0.5.0",
     "@signalk/client": "^2.3.0",
     "dotenv": "^16.4.5",
-    "isolated-vm": "^5.0.1",
     "ws": "^8.18.0"
+  },
+  "optionalDependencies": {
+    "isolated-vm": "^6.1.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/execution-engine/isolate-sandbox.ts
+++ b/src/execution-engine/isolate-sandbox.ts
@@ -81,6 +81,20 @@ export class IsolateSandbox {
   }
 
   /**
+   * Whether the optional isolated-vm native addon can be loaded in this runtime.
+   * Lets the server decide up front whether code execution will work (and fall
+   * back to the direct read tools when it won't). The result is cached.
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      await loadIvm();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Execute code in a fresh V8 isolate
    *
    * @param code - JavaScript/TypeScript code to execute

--- a/src/execution-engine/isolate-sandbox.ts
+++ b/src/execution-engine/isolate-sandbox.ts
@@ -83,7 +83,8 @@ export class IsolateSandbox {
   /**
    * Whether the optional isolated-vm native addon can be loaded in this runtime.
    * Lets the server decide up front whether code execution will work (and fall
-   * back to the direct read tools when it won't). The result is cached.
+   * back to the direct read tools when it won't). The module load is cached by
+   * loadIvm, so repeat calls are cheap once it has succeeded.
    */
   async isAvailable(): Promise<boolean> {
     try {

--- a/src/execution-engine/isolate-sandbox.ts
+++ b/src/execution-engine/isolate-sandbox.ts
@@ -1,4 +1,22 @@
-import ivm from 'isolated-vm';
+/**
+ * Lazily loads the optional native `isolated-vm` addon.
+ *
+ * isolated-vm is a native module that must be compiled for the running Node ABI
+ * and does not ship a prebuilt binary for every Node version (notably it fails
+ * to build on Node 25). It is declared in `optionalDependencies` and imported
+ * dynamically so that importing this module — or constructing IsolateSandbox —
+ * never loads the addon. The addon is resolved only when code is actually
+ * executed, and a load failure degrades gracefully (see `execute`) instead of
+ * crashing the MCP server at startup.
+ */
+let ivmModule: any = null;
+async function loadIvm(): Promise<any> {
+  if (!ivmModule) {
+    const mod: any = await import('isolated-vm');
+    ivmModule = mod?.default ?? mod;
+  }
+  return ivmModule;
+}
 
 /**
  * Result of code execution in V8 isolate
@@ -87,7 +105,27 @@ export class IsolateSandbox {
     const startTime = Date.now();
     const logs: string[] = [];
 
-    let isolate: ivm.Isolate | null = null;
+    // Lazily load the optional native addon. If it cannot be loaded (e.g. there
+    // is no isolated-vm build for the running Node.js version), degrade
+    // gracefully so the MCP server keeps serving instead of crashing.
+    let ivm: any;
+    try {
+      ivm = await loadIvm();
+    } catch (error: any) {
+      return {
+        success: false,
+        error:
+          'Code execution engine (isolated-vm) is unavailable in this runtime. ' +
+          'isolated-vm is an optional native addon that must be built for the ' +
+          'running Node.js version; run the server under a Node.js version with ' +
+          'a working isolated-vm build (e.g. Node 22 LTS) to enable execute_code. ' +
+          `Underlying error: ${error?.message || String(error)}`,
+        logs,
+        executionTime: Date.now() - startTime,
+      };
+    }
+
+    let isolate: any = null;
 
     try {
       // Create fresh V8 isolate with memory limit
@@ -117,7 +155,7 @@ export class IsolateSandbox {
 
       // Inject bindings (RPC-style access to external systems)
       for (const [name, binding] of Object.entries(bindings)) {
-        await this.injectBinding(context, name, binding);
+        await this.injectBinding(ivm, context, name, binding);
       }
 
       // Execute code with timeout
@@ -160,7 +198,8 @@ export class IsolateSandbox {
    * @private
    */
   private async injectBinding(
-    context: ivm.Context,
+    ivm: any,
+    context: any,
     name: string,
     binding: any
   ): Promise<void> {

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -316,13 +316,14 @@ describe('SignalKMCPServer', () => {
       }) as any;
 
     test('code mode serves the direct read tools and drops execute_code when the addon is unavailable', async () => {
-      new SignalKMCPServer({
+      const server = new SignalKMCPServer({
         executionMode: 'code',
         sandbox: unavailableSandbox(),
       });
+      await server.run(); // run() probes availability before serving
       const listToolsHandler = mockServer.setRequestHandler.mock
-        .calls[0][1] as () => Promise<any>;
-      const result = await listToolsHandler();
+        .calls[0][1] as () => any;
+      const result = listToolsHandler();
       const names = result.tools.map((t: any) => t.name);
       expect(names).toContain('get_vessel_state');
       expect(names).toContain('get_path_value');
@@ -336,10 +337,11 @@ describe('SignalKMCPServer', () => {
         data: {},
         timestamp: '2026-06-12T00:00:00.000Z',
       } as any);
-      new SignalKMCPServer({
+      const server = new SignalKMCPServer({
         executionMode: 'code',
         sandbox: unavailableSandbox(),
       });
+      await server.run();
       const callToolHandler = mockServer.setRequestHandler.mock
         .calls[1][1] as (request: any) => Promise<any>;
       const result = await callToolHandler({
@@ -350,11 +352,13 @@ describe('SignalKMCPServer', () => {
     });
 
     test('normal code mode (addon available) still advertises execute_code only', async () => {
-      // default mocked sandbox: isAvailable -> true
-      new SignalKMCPServer({ executionMode: 'code' });
+      // default mocked sandbox: isAvailable -> true; even after run() the addon
+      // is available, so execute_code stays and the direct tools are not added.
+      const server = new SignalKMCPServer({ executionMode: 'code' });
+      await server.run();
       const listToolsHandler = mockServer.setRequestHandler.mock
-        .calls[0][1] as () => Promise<any>;
-      const result = await listToolsHandler();
+        .calls[0][1] as () => any;
+      const result = listToolsHandler();
       const names = result.tools.map((t: any) => t.name);
       expect(names).toContain('execute_code');
       expect(names).not.toContain('get_vessel_state');

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -363,6 +363,31 @@ describe('SignalKMCPServer', () => {
       expect(names).toContain('execute_code');
       expect(names).not.toContain('get_vessel_state');
     });
+
+    test('hybrid mode degraded: advertises the direct tools and drops execute_code', async () => {
+      const server = new SignalKMCPServer({
+        executionMode: 'hybrid',
+        sandbox: unavailableSandbox(),
+      });
+      await server.run();
+      const listToolsHandler = mockServer.setRequestHandler.mock
+        .calls[0][1] as () => any;
+      const names = listToolsHandler().tools.map((t: any) => t.name);
+      expect(names).toContain('get_vessel_state');
+      expect(names).not.toContain('execute_code');
+    });
+
+    test('normal code mode (addon available) rejects a direct read tool', async () => {
+      const server = new SignalKMCPServer({ executionMode: 'code' });
+      await server.run(); // addon available -> not degraded
+      const callToolHandler = mockServer.setRequestHandler.mock
+        .calls[1][1] as (request: any) => Promise<any>;
+      await expect(
+        callToolHandler({
+          params: { name: 'get_vessel_state', arguments: {} },
+        }),
+      ).rejects.toThrow(/code-only mode/);
+    });
   });
 
   describe('Tool execution', () => {

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -65,6 +65,23 @@ jest.mock('./signalk-client', () => ({
 }));
 const MockedSignalKClient = jest.mocked(SignalKClient);
 
+// Mock the isolate sandbox so the server spec never loads the native isolated-vm
+// addon (it is excluded from the unit suite). isAvailable defaults to true; the
+// degraded-mode test injects its own sandbox with isAvailable:false.
+jest.mock('./execution-engine/isolate-sandbox', () => ({
+  IsolateSandbox: jest.fn().mockImplementation(() => ({
+    isAvailable: jest.fn(() => Promise.resolve(true)),
+    execute: jest.fn(() =>
+      Promise.resolve({
+        success: true,
+        result: undefined,
+        logs: [],
+        executionTime: 0,
+      }),
+    ),
+  })),
+}));
+
 // Mock the MCP SDK components
 const mockServer = {
   setRequestHandler: jest.fn(),
@@ -288,6 +305,59 @@ describe('SignalKMCPServer', () => {
       expect(aisTargetsTool.inputSchema.properties.page.type).toBe('number');
       expect(aisTargetsTool.inputSchema.properties.pageSize.type).toBe('number');
       expect(aisTargetsTool.inputSchema.properties.pageSize.maximum).toBe(50);
+    });
+  });
+
+  describe('Degraded mode (isolated-vm unavailable)', () => {
+    const unavailableSandbox = () =>
+      ({
+        isAvailable: jest.fn(() => Promise.resolve(false)),
+        execute: jest.fn(),
+      }) as any;
+
+    test('code mode serves the direct read tools and drops execute_code when the addon is unavailable', async () => {
+      new SignalKMCPServer({
+        executionMode: 'code',
+        sandbox: unavailableSandbox(),
+      });
+      const listToolsHandler = mockServer.setRequestHandler.mock
+        .calls[0][1] as () => Promise<any>;
+      const result = await listToolsHandler();
+      const names = result.tools.map((t: any) => t.name);
+      expect(names).toContain('get_vessel_state');
+      expect(names).toContain('get_path_value');
+      expect(names).not.toContain('execute_code');
+    });
+
+    test('code mode dispatches a direct read tool when degraded', async () => {
+      mockSignalKClient.getVesselState.mockResolvedValue({
+        connected: true,
+        context: 'vessels.self',
+        data: {},
+        timestamp: '2026-06-12T00:00:00.000Z',
+      } as any);
+      new SignalKMCPServer({
+        executionMode: 'code',
+        sandbox: unavailableSandbox(),
+      });
+      const callToolHandler = mockServer.setRequestHandler.mock
+        .calls[1][1] as (request: any) => Promise<any>;
+      const result = await callToolHandler({
+        params: { name: 'get_vessel_state', arguments: {} },
+      });
+      expect(result.content[0].type).toBe('text');
+      expect(mockSignalKClient.getVesselState).toHaveBeenCalled();
+    });
+
+    test('normal code mode (addon available) still advertises execute_code only', async () => {
+      // default mocked sandbox: isAvailable -> true
+      new SignalKMCPServer({ executionMode: 'code' });
+      const listToolsHandler = mockServer.setRequestHandler.mock
+        .calls[0][1] as () => Promise<any>;
+      const result = await listToolsHandler();
+      const names = result.tools.map((t: any) => t.name);
+      expect(names).toContain('execute_code');
+      expect(names).not.toContain('get_vessel_state');
     });
   });
 

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -31,6 +31,11 @@ export interface SignalKMCPServerOptions {
    * - 'hybrid': Both tools and code execution available (for migration only)
    */
   executionMode?: 'tools' | 'code' | 'hybrid';
+  /**
+   * Inject a sandbox (mainly for tests). Defaults to a new IsolateSandbox.
+   * Lets a test drive the isolated-vm-unavailable (degraded) path.
+   */
+  sandbox?: IsolateSandbox;
 }
 
 /**
@@ -72,6 +77,10 @@ export class SignalKMCPServer {
   private sandbox?: IsolateSandbox;
   private binding?: SignalKBinding;
   private sdkCode?: string;
+  // Whether the isolated-vm addon is loadable. Probed once, lazily; until then
+  // we assume code execution works (optimistic).
+  private codeExecutionProbed = false;
+  private codeExecutionAvailable = true;
 
   /**
    * Creates a new SignalK MCP Server instance with configuration from options or environment variables
@@ -133,7 +142,7 @@ export class SignalKMCPServer {
 
     // Initialize code execution components if needed
     if (this.executionMode === 'code' || this.executionMode === 'hybrid') {
-      this.sandbox = new IsolateSandbox();
+      this.sandbox = options.sandbox || new IsolateSandbox();
       this.binding = new SignalKBinding(this.signalkClient);
 
       // Generate SDK code from tools

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -441,17 +441,53 @@ export class SignalKMCPServer {
    * // - get_path_value({"path": "navigation.position"})
    * // - execute_code({"code": "const vessel = await getVesselState(); ..."})
    */
+  /**
+   * Probe (once) whether the isolated-vm addon is loadable, so the server can
+   * fall back to the direct read tools when it isn't.
+   */
+  private async ensureCodeExecutionProbe(): Promise<void> {
+    if (this.codeExecutionProbed) {
+      return;
+    }
+    this.codeExecutionProbed = true;
+    if (this.sandbox) {
+      this.codeExecutionAvailable = await this.sandbox.isAvailable();
+      if (!this.codeExecutionAvailable) {
+        console.error(
+          '[DEGRADED MODE] isolated-vm is unavailable; serving the direct read ' +
+            'tools instead of execute_code.',
+        );
+      }
+    }
+  }
+
+  /** Code-execution mode, but the isolate addon could not be loaded. */
+  private get codeExecutionDegraded(): boolean {
+    return (
+      (this.executionMode === 'code' || this.executionMode === 'hybrid') &&
+      !this.codeExecutionAvailable
+    );
+  }
+
   setupToolHandlers(): void {
     this.server.setRequestHandler(ListToolsRequestSchema, () => {
       const tools: any[] = [];
 
-      // Add legacy tools if in 'tools' or 'hybrid' mode
-      if (this.executionMode === 'tools' || this.executionMode === 'hybrid') {
+      // Add the direct read tools in 'tools'/'hybrid' mode, or as a fallback
+      // when code execution is degraded (the isolate addon could not load).
+      if (
+        this.executionMode === 'tools' ||
+        this.executionMode === 'hybrid' ||
+        this.codeExecutionDegraded
+      ) {
         tools.push(...this.getToolDefinitions());
       }
 
-      // Add execute_code tool if in 'code' or 'hybrid' mode
-      if (this.executionMode === 'code' || this.executionMode === 'hybrid') {
+      // Add execute_code only when code execution actually works.
+      if (
+        (this.executionMode === 'code' || this.executionMode === 'hybrid') &&
+        this.codeExecutionAvailable
+      ) {
         tools.push({
           name: 'execute_code',
           description:
@@ -496,8 +532,13 @@ export class SignalKMCPServer {
             return await this.executeCode(args.code);
           }
 
-          // Handle legacy tools (only in tools/hybrid mode)
-          if (this.executionMode === 'tools' || this.executionMode === 'hybrid') {
+          // Handle the direct read tools: in tools/hybrid mode, or as a fallback
+          // when code execution is degraded (the isolate addon could not load).
+          if (
+            this.executionMode === 'tools' ||
+            this.executionMode === 'hybrid' ||
+            this.codeExecutionDegraded
+          ) {
             switch (name) {
               case 'get_vessel_state':
                 return await this.getVesselState();
@@ -972,6 +1013,9 @@ export class SignalKMCPServer {
    * // "signalk-mcp-server v1.0.0 running on stdio"
    */
   async run(): Promise<void> {
+    // Probe code-execution availability before serving so the tool list
+    // reflects degraded mode from the first request.
+    await this.ensureCodeExecutionProbe();
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     console.error(`${this.serverName} v${this.serverVersion} running on stdio`);


### PR DESCRIPTION
**Branch:** `isolated-vm-degraded-mode` → targets `main`

## Stack & merge order

Builds on **#6 `fix/lazy-optional-isolated-vm`** (already open here, **not yet merged**).
It targets `main` because that parent branch isn't on `main` yet, so this PR's diff includes
#6's commit until that lands. **Merge #6 first.**

This is a separate one-step stack from the `feat/history-api` chain (#11–#22): degraded mode
only makes sense once a missing `isolated-vm` addon fails catchably at runtime, which is exactly
what #6 provides — so it can't sit on the read-only `feat/history-api` chain.

| Step | PR | Branch |
|------|----|--------|
| prereq | #6 | `fix/lazy-optional-isolated-vm` — open here, **not yet merged** |
| 1 | #23 | `isolated-vm-degraded-mode` ⬅ **this PR** |

---
## Summary

`isolated-vm` is an optional native addon that may not build for every Node
runtime. Today, when it can't load, `execute_code` just returns an error and the
server has no usable data tools. This makes the server **degrade gracefully**:
when the addon is unavailable, it serves the direct read tools instead.

## What changed

- **`IsolateSandbox.isAvailable()`** — probes whether the addon can load (cached).
- **The server probes once, in `run()`**, before it starts serving, and records
  `codeExecutionAvailable`. (Optimistic default `true` until probed.)
- **Degraded mode** (`code`/`hybrid` mode + addon unavailable):
  - `ListTools` advertises the **direct read tools** (`get_vessel_state`,
    `get_ais_targets`, …) and **drops `execute_code`** (which couldn't work).
  - `CallTool` **dispatches** those tools instead of returning the
    "use execute_code" error.
  - A console note is logged once when degrading.
- When the addon **is** available, behaviour is unchanged (`execute_code` only in
  code mode). Tools/hybrid mode are unaffected.
- **Constructor sandbox seam** (`options.sandbox`) so a test can inject an
  unavailable sandbox.

## Testing

- 3 server tests: degraded code mode serves the direct read tools and drops
  `execute_code`; degraded code mode dispatches a direct read tool; normal code
  mode (addon available) still advertises `execute_code` only.
- The server spec now mocks the sandbox module so the unit suite never loads the
  native addon (consistent with `isolate-sandbox.spec.ts` being excluded).
- `npm run typecheck`, `npm run test:unit`, `npm run lint` clean. Reviewed for
  edge cases before merging.

## Notes

- Production always calls `run()` at startup, so the probe completes before any
  client request. If the server is embedded without `run()`, it stays optimistic
  and `execute_code` returns its informative "addon unavailable" error.

## Commits

```
Add isolated-vm degraded-mode with failing tests (red)
Serve the direct read tools when isolated-vm is unavailable (green)
Harden degraded mode from the review
```
