### PR TITLE
Add multi-client support: tool annotations and per-client setup guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the SignalK MCP Server project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Setup guides for connecting nine MCP clients under `docs/clients/`: Claude
+  Code, Claude Desktop, Codex, Gemini CLI, Cursor, VS Code (GitHub Copilot),
+  Windsurf, Cline, and Zed. Each is plain-language and copy-paste friendly, with
+  a shared checklist (requirements, connection settings, troubleshooting) and an
+  honest note about which web/cloud assistants can't connect yet.
+- MCP tool annotations on the tool list. The read tools advertise
+  `readOnlyHint: true`; `execute_code` advertises `readOnlyHint: false`,
+  `destructiveHint: false`, and `openWorldHint: true`, so a client can show the
+  right consent prompt (auto-run a safe read, ask before running code).
+
+### Changed
+- The README now links to a per-client setup guide from a table instead of
+  documenting only Claude Desktop.
+
 ## [1.0.8] - 2025-11-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,25 +25,26 @@ npx signalk-mcp-server
 npm install -g signalk-mcp-server
 ```
 
-### Claude Desktop Configuration
+### Connect your AI assistant
 
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+This server works with any assistant that supports MCP and runs on your own
+computer. Pick yours for step-by-step setup:
 
-```json
-{
-  "mcpServers": {
-    "signalk": {
-      "command": "npx",
-      "args": ["signalk-mcp-server"],
-      "env": {
-        "SIGNALK_HOST": "localhost",
-        "SIGNALK_PORT": "3000",
-        "SIGNALK_TLS": "false"
-      }
-    }
-  }
-}
-```
+| Assistant | Guide |
+|-----------|-------|
+| Claude Code | [docs/clients/claude-code.md](docs/clients/claude-code.md) |
+| Claude Desktop | [docs/clients/claude-desktop.md](docs/clients/claude-desktop.md) |
+| Codex (OpenAI) | [docs/clients/codex-cli.md](docs/clients/codex-cli.md) |
+| Gemini CLI (Google) | [docs/clients/gemini-cli.md](docs/clients/gemini-cli.md) |
+| Cursor | [docs/clients/cursor.md](docs/clients/cursor.md) |
+| VS Code (GitHub Copilot) | [docs/clients/vscode.md](docs/clients/vscode.md) |
+| Windsurf | [docs/clients/windsurf.md](docs/clients/windsurf.md) |
+| Cline | [docs/clients/cline.md](docs/clients/cline.md) |
+| Zed | [docs/clients/zed.md](docs/clients/zed.md) |
+
+New to MCP, or don't see your assistant? Start with the
+[setup checklist](docs/clients/README.md), which also explains why the web
+versions of ChatGPT and Claude.ai can't connect yet.
 
 ### Basic Usage
 
@@ -392,7 +393,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [CHANGELOG.md](CHANGELOG.md) - Version history and migration guide
 - [TOOL-MIGRATION-GUIDE.md](TOOL-MIGRATION-GUIDE.md) - Detailed migration examples
-- [Claude Desktop MCP Docs](https://modelcontextprotocol.io/docs/tools/claude-desktop)
+- [Connecting your AI assistant](docs/clients/README.md) - setup guides for each supported client
 
 ## Credits
 

--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -34,7 +34,8 @@ You need three things:
 
 ### Your SignalK connection details
 
-You give these to the assistant as environment variables. Change the example
+You give these to the assistant as settings. In the config files further down
+they go in a section called `env` (short for "environment"). Change the example
 values to match your own server.
 
 | Setting | What it is | Example |
@@ -58,13 +59,19 @@ that. The only difference between assistants is **which file** they read and
 **what they call the section** that holds the server. Each guide gives you the
 exact file and the exact text.
 
-## Web assistants (the ChatGPT and Claude.ai websites)
+## Web and cloud assistants (ChatGPT, the Claude.ai website)
 
-These can't connect yet, and that's a real limit, not a missing setup step. A
-website can only reach a server that is published on the public internet over a
-secure (HTTPS) address. This server is built to run on your own machine and talk
-over a local connection, so a website has no way to reach it. Use one of the
-desktop or command-line assistants above instead.
+Some assistants can't connect yet, and that's a real limit, not a missing setup
+step. They can only reach a server that is published on the public internet over
+a secure (HTTPS) address. This server is built to run on your own machine and
+talk over a local connection, so they have no way to reach it. This applies to:
+
+- **ChatGPT** — both the website and the desktop app only connect to servers on
+  the internet, not to one running on your own computer.
+- **The Claude.ai website.** The **Claude desktop app is different** and _can_
+  run this local server — see the [Claude Desktop guide](claude-desktop.md).
+
+For everything else, use one of the desktop or command-line assistants above.
 
 ## If something doesn't work
 

--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -1,0 +1,83 @@
+# Connect your AI assistant
+
+This SignalK MCP server lets an AI assistant read live data from your boat —
+position, AIS targets, alarms, and more. These guides show how to connect the
+assistant you use. Each one is short and copy-paste friendly.
+
+## Pick your assistant
+
+| Assistant | Type | Guide |
+|-----------|------|-------|
+| Claude Code | Command line | [claude-code.md](claude-code.md) |
+| Claude Desktop | Desktop app | [claude-desktop.md](claude-desktop.md) |
+| Codex (OpenAI) | Command line + editor | [codex-cli.md](codex-cli.md) |
+| Gemini CLI (Google) | Command line | [gemini-cli.md](gemini-cli.md) |
+| Cursor | Code editor | [cursor.md](cursor.md) |
+| VS Code (GitHub Copilot) | Code editor | [vscode.md](vscode.md) |
+| Windsurf | Code editor | [windsurf.md](windsurf.md) |
+| Cline | VS Code extension | [cline.md](cline.md) |
+| Zed | Code editor | [zed.md](zed.md) |
+
+Don't see yours? Most assistants that support MCP use one of the formats above.
+The [config in plain terms](#the-config-in-plain-terms) section explains the
+pieces so you can adapt them.
+
+## Before you start
+
+You need three things:
+
+1. **Node.js 18 or newer.** This comes with the `npx` command the assistant uses
+   to start the server. Check it by running `node --version`. If you don't have
+   it, install it from [nodejs.org](https://nodejs.org/).
+2. **A running SignalK server** that this computer can reach.
+3. **Your SignalK connection details** (below).
+
+### Your SignalK connection details
+
+You give these to the assistant as environment variables. Change the example
+values to match your own server.
+
+| Setting | What it is | Example |
+|---------|------------|---------|
+| `SIGNALK_HOST` | The address of your SignalK server. If it runs on this same computer, use `localhost`. | `localhost` |
+| `SIGNALK_PORT` | The port your SignalK server listens on. Usually `3000`. | `3000` |
+| `SIGNALK_TLS` | `true` if your server uses a secure connection (https/wss), otherwise `false`. | `false` |
+| `SIGNALK_TOKEN` | Only needed if your server requires a login. Leave it out if it doesn't. | _(optional)_ |
+
+## The config in plain terms
+
+Every assistant starts the server the same way. It runs:
+
+```
+npx -y signalk-mcp-server
+```
+
+and passes your connection details as environment variables. You don't install
+anything by hand — `npx` downloads the server the first time and reuses it after
+that. The only difference between assistants is **which file** they read and
+**what they call the section** that holds the server. Each guide gives you the
+exact file and the exact text.
+
+## Web assistants (the ChatGPT and Claude.ai websites)
+
+These can't connect yet, and that's a real limit, not a missing setup step. A
+website can only reach a server that is published on the public internet over a
+secure (HTTPS) address. This server is built to run on your own machine and talk
+over a local connection, so a website has no way to reach it. Use one of the
+desktop or command-line assistants above instead.
+
+## If something doesn't work
+
+- **The assistant doesn't show any SignalK tools.** Fully quit and reopen the
+  assistant after you edit its config — most read the file only at startup. Also
+  check the file is valid; a single missing comma or bracket stops it loading.
+- **The first run is slow or times out.** The very first start downloads the
+  server, which can take a while on a slow connection. Open a terminal, run
+  `npx -y signalk-mcp-server` once, and when it prints that it has started press
+  `Ctrl+C` and try the assistant again.
+- **It connects but shows no data.** Check `SIGNALK_HOST`, `SIGNALK_PORT`, and
+  `SIGNALK_TLS` match your server. Confirm SignalK is running by opening
+  `http://<host>:<port>/signalk` in a browser. If your server needs a login, set
+  `SIGNALK_TOKEN`.
+- **Keep numbers and true/false in quotes.** In these config files every value
+  is text, so write `"3000"` and `"false"`, not `3000` or `false`.

--- a/docs/clients/claude-code.md
+++ b/docs/clients/claude-code.md
@@ -1,0 +1,56 @@
+# Connect Claude Code
+
+[Claude Code](https://docs.claude.com/en/docs/claude-code) is Anthropic's
+command-line assistant. This adds the SignalK server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server (easiest)
+
+Run this in a terminal, changing the values to match your server:
+
+```bash
+claude mcp add signalk \
+  -e SIGNALK_HOST=localhost \
+  -e SIGNALK_PORT=3000 \
+  -e SIGNALK_TLS=false \
+  -- npx -y signalk-mcp-server
+```
+
+- `signalk` is the name you'll see for the server. You can change it.
+- Each `-e` sets one connection detail. Add `-e SIGNALK_TOKEN=your-token` if your
+  server needs a login.
+- The `--` separates Claude Code's own options from the command that starts the
+  server. Keep it.
+
+By default the server is added for the current project only. Add `--scope user`
+to use it everywhere on your computer, or `--scope project` to write a shared
+`.mcp.json` file you can commit for your team.
+
+## Or edit the file by hand
+
+For a project, create `.mcp.json` in the project folder:
+
+```json
+{
+  "mcpServers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+## Check it works
+
+Run `claude mcp list` and look for `signalk`, or start Claude Code and ask it
+something like "what's my vessel's position?"
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/claude-desktop.md
+++ b/docs/clients/claude-desktop.md
@@ -1,0 +1,54 @@
+# Connect Claude Desktop
+
+[Claude Desktop](https://claude.com/download) is Anthropic's desktop app for
+macOS and Windows. This adds the SignalK server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Open the config file
+
+| Your computer | File to edit |
+|---------------|--------------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+You can also reach it from the app: **Settings → Developer → Edit Config**. If
+the file is empty or missing, create it with the content below. (Claude Desktop
+is not available on Linux.)
+
+## Add the server
+
+```json
+{
+  "mcpServers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+Change the values to match your server. Add `"SIGNALK_TOKEN": "your-token"`
+inside `env` if your server needs a login.
+
+## Check it works
+
+Fully quit and reopen Claude Desktop — this is required, because it reads the
+file only at startup. Then ask it something like "what's my vessel's position?"
+and the SignalK tools should be available.
+
+## Notes
+
+- **Windows:** if starting the server fails with an error mentioning `APPDATA` or
+  a file that can't be found, add
+  `"APPDATA": "C:\\Users\\<your-name>\\AppData\\Roaming\\"` inside `env`, and make
+  sure Node.js is installed.
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/cline.md
+++ b/docs/clients/cline.md
@@ -1,0 +1,54 @@
+# Connect Cline
+
+[Cline](https://cline.bot) is an AI assistant that runs as a VS Code extension.
+This adds the SignalK server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server
+
+The reliable way is from inside the extension: open the **MCP Servers** icon in
+Cline and choose **Configure MCP Servers**. That opens Cline's
+`cline_mcp_settings.json` file for you, wherever it lives, and you paste the
+server into it.
+
+If you'd rather open the file yourself and you run Cline inside VS Code, it's in
+VS Code's extension storage:
+
+| Your computer | File |
+|---------------|------|
+| macOS | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Windows | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json` |
+| Linux | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+
+Add the server:
+
+```json
+{
+  "mcpServers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+Change the values to match your server. Add `"SIGNALK_TOKEN": "your-token"`
+inside `env` if your server needs a login. `"disabled": false` keeps the server
+on, and `"autoApprove": []` means Cline asks before each tool runs — you can
+leave both as shown.
+
+## Check it works
+
+Open the MCP Servers panel in Cline; `signalk` should show as connected.
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/codex-cli.md
+++ b/docs/clients/codex-cli.md
@@ -1,0 +1,60 @@
+# Connect Codex (OpenAI)
+
+[Codex](https://developers.openai.com/codex) is OpenAI's coding assistant. It
+comes as a command-line tool and as an editor extension, and the two share the
+same setup. This adds the SignalK server to both.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server (easiest)
+
+Run this in a terminal, changing the values to match your server:
+
+```bash
+codex mcp add signalk \
+  --env SIGNALK_HOST=localhost \
+  --env SIGNALK_PORT=3000 \
+  --env SIGNALK_TLS=false \
+  -- npx -y signalk-mcp-server
+```
+
+Add `--env SIGNALK_TOKEN=your-token` if your server needs a login. The `--`
+separates Codex's options from the command that starts the server.
+
+## Or edit the file by hand
+
+Codex reads `~/.codex/config.toml`. This file uses TOML, not JSON. Add:
+
+```toml
+[mcp_servers.signalk]
+command = "npx"
+args = ["-y", "signalk-mcp-server"]
+env = { SIGNALK_HOST = "localhost", SIGNALK_PORT = "3000", SIGNALK_TLS = "false" }
+```
+
+Two things to watch for:
+
+- The section is named `mcp_servers`, with an underscore.
+- Keep every value in quotes, including `"3000"` and `"false"`. In TOML, leaving
+  the quotes off turns them into a number or a true/false value, but these
+  settings have to be plain text.
+
+## Using Codex in your editor
+
+Codex's editor extension shares the same `~/.codex/config.toml` file as the
+command line, so you only set the server up once. If you'd rather edit the file
+from the extension, open its gear menu and choose **Codex Settings → Open
+config.toml**. Everything above applies the same way.
+
+## Check it works
+
+Start Codex and run `/mcp` to see connected servers, or run `codex mcp list`.
+
+## Notes
+
+- The first start downloads the server with `npx`, which can be slow. If Codex
+  says the server timed out starting up, run `npx -y signalk-mcp-server` once in
+  a terminal to download it, then try again.
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/cursor.md
+++ b/docs/clients/cursor.md
@@ -1,0 +1,44 @@
+# Connect Cursor
+
+[Cursor](https://cursor.com) is an AI code editor. This adds the SignalK server
+to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server
+
+Edit Cursor's MCP file:
+
+| Scope | File |
+|-------|------|
+| Just this project | `.cursor/mcp.json` in the project folder |
+| Everywhere | `~/.cursor/mcp.json` |
+
+Add the server (create the file with this content if it's empty):
+
+```json
+{
+  "mcpServers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+Change the values to match your server. Add `"SIGNALK_TOKEN": "your-token"`
+inside `env` if your server needs a login.
+
+## Check it works
+
+Open **Settings → MCP** (or **Tools & Integrations → MCP**) in Cursor. You should
+see `signalk` listed and connected.
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/gemini-cli.md
+++ b/docs/clients/gemini-cli.md
@@ -1,0 +1,47 @@
+# Connect Gemini CLI (Google)
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) is Google's
+command-line assistant. This adds the SignalK server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server
+
+Edit Gemini's settings file:
+
+| Scope | File |
+|-------|------|
+| Just this project | `.gemini/settings.json` in the project folder |
+| Everywhere | `~/.gemini/settings.json` |
+
+Add the server (create the file with this content if it's empty):
+
+```json
+{
+  "mcpServers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+Change the values to match your server. Add `"SIGNALK_TOKEN": "your-token"`
+inside `env` if your server needs a login.
+
+Recent versions of Gemini CLI also have a `gemini mcp add` command, but the
+settings file above works on every version and is the simplest to get right.
+
+## Check it works
+
+Start Gemini CLI and run `/mcp` to list connected servers, then ask it something
+like "what's my vessel's position?"
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/vscode.md
+++ b/docs/clients/vscode.md
@@ -1,0 +1,44 @@
+# Connect VS Code (GitHub Copilot)
+
+VS Code's [GitHub Copilot](https://code.visualstudio.com/docs/copilot/overview)
+can use MCP servers in agent mode. This adds the SignalK server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server
+
+Create a file named `.vscode/mcp.json` in your project folder. **VS Code is
+different from most assistants in two ways:** the section is called `servers`
+(not `mcpServers`), and each server needs a `"type": "stdio"` line.
+
+```json
+{
+  "servers": {
+    "signalk": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+Change the values to match your server. Add `"SIGNALK_TOKEN": "your-token"`
+inside `env` if your server needs a login.
+
+To make the server available in every project instead of just one, run
+**MCP: Open User Configuration** from the Command Palette and add the same
+`signalk` block there.
+
+## Check it works
+
+Open Copilot Chat, switch to **Agent** mode, and open the tools list — `signalk`
+should appear. Then ask something like "what's my vessel's position?"
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/windsurf.md
+++ b/docs/clients/windsurf.md
@@ -1,0 +1,44 @@
+# Connect Windsurf
+
+[Windsurf](https://windsurf.com) is an AI code editor. This adds the SignalK
+server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server
+
+Edit Windsurf's MCP file:
+
+```
+~/.codeium/windsurf/mcp_config.json
+```
+
+Add the server (create the file with this content if it's empty):
+
+```json
+{
+  "mcpServers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+Change the values to match your server. Add `"SIGNALK_TOKEN": "your-token"`
+inside `env` if your server needs a login. You can also open this file from
+**Windsurf Settings → Cascade → MCP servers → Manage MCPs**.
+
+## Check it works
+
+Open the MCP servers panel in Windsurf (Cascade) and refresh — `signalk` should
+appear and connect.
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/docs/clients/zed.md
+++ b/docs/clients/zed.md
@@ -1,0 +1,47 @@
+# Connect Zed
+
+[Zed](https://zed.dev) is a fast code editor with AI built in. This adds the
+SignalK server to it.
+
+New to this? Read the [setup checklist](README.md) first — you'll need Node.js
+and your SignalK connection details.
+
+## Add the server
+
+Open Zed's settings file:
+
+| Your computer | File |
+|---------------|------|
+| macOS / Linux | `~/.config/zed/settings.json` |
+| Windows | `%APPDATA%\Zed\settings.json` |
+
+You can also open it from Zed: **Command Palette → `zed: open settings`**. Add a
+`context_servers` section — note Zed calls it `context_servers`, not
+`mcpServers`:
+
+```json
+{
+  "context_servers": {
+    "signalk": {
+      "command": "npx",
+      "args": ["-y", "signalk-mcp-server"],
+      "env": {
+        "SIGNALK_HOST": "localhost",
+        "SIGNALK_PORT": "3000",
+        "SIGNALK_TLS": "false"
+      }
+    }
+  }
+}
+```
+
+If your settings file already has other settings, add `context_servers` as
+another top-level key — don't replace what's there. Change the values to match
+your server, and add `"SIGNALK_TOKEN": "your-token"` inside `env` if your server
+needs a login.
+
+## Check it works
+
+Open the AI panel in Zed and check the tools list — `signalk` should appear.
+
+Trouble? See [If something doesn't work](README.md#if-something-doesnt-work).

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -289,6 +289,26 @@ describe('SignalKMCPServer', () => {
       expect(aisTargetsTool.inputSchema.properties.pageSize.type).toBe('number');
       expect(aisTargetsTool.inputSchema.properties.pageSize.maximum).toBe(50);
     });
+
+    test('every read tool carries readOnlyHint:true', async () => {
+      new SignalKMCPServer({ executionMode: 'tools' });
+      const listToolsHandler = mockServer.setRequestHandler.mock
+        .calls[0][1] as () => any;
+      const result = await listToolsHandler();
+      for (const tool of result.tools) {
+        expect(tool.annotations?.readOnlyHint).toBe(true);
+      }
+    });
+
+    test('execute_code is annotated not-read-only and open-world', async () => {
+      new SignalKMCPServer({ executionMode: 'hybrid' });
+      const listToolsHandler = mockServer.setRequestHandler.mock
+        .calls[0][1] as () => any;
+      const result = await listToolsHandler();
+      const ec = result.tools.find((t: any) => t.name === 'execute_code');
+      expect(ec.annotations.readOnlyHint).toBe(false);
+      expect(ec.annotations.openWorldHint).toBe(true);
+    });
   });
 
   describe('Tool execution', () => {

--- a/src/signalk-mcp-server.spec.ts
+++ b/src/signalk-mcp-server.spec.ts
@@ -292,21 +292,26 @@ describe('SignalKMCPServer', () => {
 
     test('every read tool carries readOnlyHint:true', async () => {
       new SignalKMCPServer({ executionMode: 'tools' });
-      const listToolsHandler = mockServer.setRequestHandler.mock
-        .calls[0][1] as () => any;
+      const listToolsHandler = mockServer.setRequestHandler.mock.calls.find(
+        (call: any[]) => call[0] === 'ListToolsRequestSchema',
+      )?.[1] as () => any;
       const result = await listToolsHandler();
+      expect(result.tools.length).toBeGreaterThan(0);
       for (const tool of result.tools) {
         expect(tool.annotations?.readOnlyHint).toBe(true);
       }
     });
 
-    test('execute_code is annotated not-read-only and open-world', async () => {
+    test('execute_code is annotated not-read-only, non-destructive, open-world', async () => {
       new SignalKMCPServer({ executionMode: 'hybrid' });
-      const listToolsHandler = mockServer.setRequestHandler.mock
-        .calls[0][1] as () => any;
+      const listToolsHandler = mockServer.setRequestHandler.mock.calls.find(
+        (call: any[]) => call[0] === 'ListToolsRequestSchema',
+      )?.[1] as () => any;
       const result = await listToolsHandler();
       const ec = result.tools.find((t: any) => t.name === 'execute_code');
+      expect(ec).toBeDefined();
       expect(ec.annotations.readOnlyHint).toBe(false);
+      expect(ec.annotations.destructiveHint).toBe(false);
       expect(ec.annotations.openWorldHint).toBe(true);
     });
   });

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -251,6 +251,7 @@ export class SignalKMCPServer {
     name: string;
     description: string;
     inputSchema: any;
+    annotations?: { readOnlyHint?: boolean; openWorldHint?: boolean };
   }> {
     return [
       {
@@ -392,7 +393,13 @@ export class SignalKMCPServer {
           additionalProperties: false,
         },
       },
-    ];
+      // Every tool here only reads from the SignalK server, so they all carry
+      // readOnlyHint:true. Clients use this to show "safe to run" in their
+      // approval UI. execute_code is annotated separately (it is not read-only).
+    ].map((tool) => ({
+      ...tool,
+      annotations: { readOnlyHint: true },
+    }));
   }
 
   /**
@@ -464,6 +471,11 @@ export class SignalKMCPServer {
             required: ['code'],
             additionalProperties: false,
           },
+          // execute_code runs caller-supplied JavaScript. The SignalK binding it
+          // exposes is read-only, but arbitrary code is something a client should
+          // approve rather than auto-run, so readOnlyHint is false. It reaches an
+          // external SignalK server, so openWorldHint is true.
+          annotations: { readOnlyHint: false, openWorldHint: true },
         });
       }
 

--- a/src/signalk-mcp-server.ts
+++ b/src/signalk-mcp-server.ts
@@ -251,7 +251,11 @@ export class SignalKMCPServer {
     name: string;
     description: string;
     inputSchema: any;
-    annotations?: { readOnlyHint?: boolean; openWorldHint?: boolean };
+    annotations?: {
+      readOnlyHint?: boolean;
+      destructiveHint?: boolean;
+      openWorldHint?: boolean;
+    };
   }> {
     return [
       {
@@ -473,9 +477,15 @@ export class SignalKMCPServer {
           },
           // execute_code runs caller-supplied JavaScript. The SignalK binding it
           // exposes is read-only, but arbitrary code is something a client should
-          // approve rather than auto-run, so readOnlyHint is false. It reaches an
-          // external SignalK server, so openWorldHint is true.
-          annotations: { readOnlyHint: false, openWorldHint: true },
+          // approve rather than auto-run, so readOnlyHint is false. The binding
+          // has no write or delete methods, so destructiveHint is false — without
+          // it, the spec defaults destructiveHint to true once readOnlyHint is
+          // false. It reaches an external SignalK server, so openWorldHint is true.
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            openWorldHint: true,
+          },
         });
       }
 


### PR DESCRIPTION
**Branch:** `mcp-client-support` → targets `main`

## Stack & merge order

**Standalone.** Based directly on `main` — depends on nothing else and can be reviewed and
merged on its own. (Submitted alongside the `feat/history-api` read-only stack, #11–#22, and
the degraded-mode PR #23, but independent of them.)

---
## Summary

Makes the server work cleanly with the common MCP clients and documents how to
connect each one. Two parts: standard MCP tool annotations so a client can
handle consent correctly, and a plain-language setup guide for every supported
assistant.

## What changed

### Tool annotations (code)

- The read tools advertise `readOnlyHint: true`.
- `execute_code` advertises `readOnlyHint: false`, `destructiveHint: false`, and
  `openWorldHint: true`. It runs caller-supplied code, so a client should ask
  before running it; but its SignalK binding is read-only with no write or
  delete method, so it can't destroy anything (without `destructiveHint: false`
  the spec would default it to `true` once `readOnlyHint` is `false`).
- These are additive hints on the tool list — no tool behaviour changes. The SDK
  code generator only reads name/description/inputSchema, so the generated
  isolate functions are unaffected.

### Connecting docs

- New `docs/clients/` folder with a short guide per assistant: Claude Code,
  Claude Desktop, Codex (command line + editor extension), Gemini CLI, Cursor,
  VS Code (GitHub Copilot), Windsurf, Cline, and Zed.
- `docs/clients/README.md` is a shared checklist: requirements, the connection
  settings, troubleshooting, and an honest note that the ChatGPT and Claude.ai
  web/cloud apps can't connect yet (they need a server on a public HTTPS
  address; this one runs locally).
- The top-level README's Claude-Desktop-only configuration block is replaced
  with a table linking to each guide, so no single client is treated as the
  default.
- Each client's config (file path, root key, whether a `type` field is needed,
  CLI command) was checked against that vendor's official docs. The differences
  that bite people are called out in-line: VS Code uses `servers` and requires
  `"type": "stdio"`; Zed uses `context_servers`; Codex uses a `mcp_servers` TOML
  table with quoted values.

## Testing

- Two new server tests assert the annotations (read tools read-only;
  `execute_code` not-read-only / non-destructive / open-world).
- `npm run typecheck`, `npm run test:unit` (133 passing), and `npm run lint`
  are clean. The docs were reviewed for config accuracy against official sources
  and for plain-language readability.

## Notes

- Web/cloud clients (ChatGPT, the Claude.ai website) are intentionally out of
  scope. They require a remote HTTPS (Streamable HTTP) transport, which is a
  larger change with its own security trade-offs around exposing live vessel
  data. The docs say this plainly rather than implying those clients work.

## Commits

```
Add failing tests for tool annotations (red)
Annotate tools with read-only / open-world hints (green)
Add per-client setup guides and link them from the README
Apply code review feedback
```
